### PR TITLE
telemetryStatsServerP check - issue 33

### DIFF
--- a/tests/telemetryStatsServerP.json_neg
+++ b/tests/telemetryStatsServerP.json_neg
@@ -1,0 +1,20 @@
+{
+  "totalCount": "1",
+  "imdata": [
+    {
+      "telemetryStatsServerP": {
+        "attributes": {
+          "name": "default",
+          "collectorLocation": "none",
+          "dn": "uni/fabric/servers/stserverp-default",
+          "dstAddr": "kafka.service.apic.local",
+          "dstPort": "9092",
+          "ip": "0.0.0.0",
+          "isSecure": "yes",
+          "modTs": "2022-09-23T10:42:34.737-04:00",
+          "rn": "stserverp-default"
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -19,7 +19,8 @@ def upgradePaths():
             {"cversion": "3.2(1a)", "tversion": "4.2(4d)"},
             {"cversion": "3.2(1a)", "tversion": "5.2(6a)"},
             {"cversion": "4.2(3a)", "tversion": "4.2(7d)"},
-            {"cversion": "2.2(3a)", "tversion": "2.2(4r)"}]
+            {"cversion": "2.2(3a)", "tversion": "2.2(4r)"},
+            {"cversion": "5.2(1a)", "tversion": None}]
 
 
 # New Check, migrate to script once logic confirmed
@@ -64,72 +65,44 @@ def test_llfc_susceptibility_check(upgradePaths):
             assert llfc_susceptibility_check(pathnum, pathlen, **testdata) == script.PASS
 
 
-
-# New Check, migrate to script once logic confirmed
-def stale_nir_object_check(index, total_checks, cversion=None, tversion=None, **kwargs):
-    title = 'NIR App Stale Object Check'
-    result = script.PASS
-    msg = ''
-    headers = ["Current version", "Target Version", "Warning"]
-    data = []
-    recommended_action = 'Manually delete the telemetryStatsServerP object prior to switch upgrade'
-    doc_url = 'https://bst.cloudapps.cisco.com/bugsearch/bug/CSCvt47850'
-    script.print_title(title, index, total_checks)
-
-    telemetryStatsServerP_json = kwargs.get("telemetryStatsServerP.json", None)
-    if not cversion:
-        cversion = kwargs.get("cversion", None)
-    if not tversion:
-        tversion = kwargs.get("tversion", None)
-    cfw = script.AciVersion(cversion)
-    tfw = script.AciVersion(tversion)
-
-    if cfw and tfw:
-        if cfw.older_than("4.2(4d)") and tfw.newer_than("5.2(2d)"):
-            if not isinstance(telemetryStatsServerP_json, list):
-                telemetryStatsServerP_json = icurl('class', 'telemetryStatsServerP.json')
-            if len(telemetryStatsServerP_json) > 0:
-                result = script.FAIL_O
-                data.append([cversion, tversion, 'telemetryStatsServerP Found'])
-
-    script.print_result(title, result, msg, headers, data, recommended_action=recommended_action, doc_url=doc_url)
-    return result
-
-
-def test_pos_stale_nir_object_check(upgradePaths):
-    script.print_title("Starting Positive stale_nir_object_check\n")
+def test_pos_telemetryStatsServerP_object_check(upgradePaths):
+    script.print_title("Starting test_pos_telemetryStatsServerP_object_check\n")
     pathlen = len(upgradePaths)
     for i, testdata in enumerate(upgradePaths):
         with open("tests/telemetryStatsServerP.json_pos","r") as file:
             testdata.update({"telemetryStatsServerP.json": json.loads(file.read())['imdata']})
         pathnum = i+1
         if pathnum == 1:
-            assert stale_nir_object_check(pathnum, pathlen, **testdata) == script.FAIL_O
+            assert script.telemetryStatsServerP_object_check(pathnum, pathlen, **testdata) == script.FAIL_O
         if pathnum == 2:
-            assert stale_nir_object_check(pathnum, pathlen, **testdata) == script.PASS
+            assert script.telemetryStatsServerP_object_check(pathnum, pathlen, **testdata) == script.PASS
         if pathnum == 3:
-            assert stale_nir_object_check(pathnum, pathlen, **testdata) == script.FAIL_O
+            assert script.telemetryStatsServerP_object_check(pathnum, pathlen, **testdata) == script.FAIL_O
         if pathnum == 4:
-            assert stale_nir_object_check(pathnum, pathlen, **testdata) == script.PASS
+            assert script.telemetryStatsServerP_object_check(pathnum, pathlen, **testdata) == script.PASS
 
 
-def test_neg_stale_nir_object_check(upgradePaths):
+def test_neg_telemetryStatsServerP_object_check(upgradePaths):
     script.print_title("Starting Negative stale_nir_object_check\n")
     pathlen = len(upgradePaths)
     for i, testdata in enumerate(upgradePaths):
-        neg_json = {"totalCount":"0","imdata":[]}
-        testdata.update({"telemetryStatsServerP.json": neg_json['imdata']})
-        
         pathnum = i+1
-
         if pathnum == 1:
-            assert stale_nir_object_check(pathnum, pathlen, **testdata) == script.PASS
+            neg_json = {"totalCount":"0","imdata":[]}
+            testdata.update({"telemetryStatsServerP.json": neg_json['imdata']})
+            assert script.telemetryStatsServerP_object_check(pathnum, pathlen, **testdata) == script.PASS
         if pathnum == 2:
-            assert stale_nir_object_check(pathnum, pathlen, **testdata) == script.PASS
+            assert script.telemetryStatsServerP_object_check(pathnum, pathlen, **testdata) == script.PASS
         if pathnum == 3:
-            assert stale_nir_object_check(pathnum, pathlen, **testdata) == script.PASS
+            with open("tests/telemetryStatsServerP.json_neg","r") as file:
+                testdata.update({"telemetryStatsServerP.json": json.loads(file.read())['imdata']})
+            assert script.telemetryStatsServerP_object_check(pathnum, pathlen, **testdata) == script.PASS
         if pathnum == 4:
-            assert stale_nir_object_check(pathnum, pathlen, **testdata) == script.PASS
+            assert script.telemetryStatsServerP_object_check(pathnum, pathlen, **testdata) == script.PASS
+        if pathnum == 5:
+            assert script.telemetryStatsServerP_object_check(pathnum, pathlen, **testdata) == script.PASS
+        if pathnum == 6:
+            assert script.telemetryStatsServerP_object_check(pathnum, pathlen, **testdata) == script.MANUAL
 
 
 def test_pos_isis_redis_metric_mpod_msite_check(upgradePaths):


### PR DESCRIPTION
pytest checks out:
```
gmonroy@x1:~/pre_upgrade_script/ACI-Pre-Upgrade-Validation-Script$ pytest
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.9.15, pytest-7.1.3, pluggy-1.0.0
rootdir: /home/gmonroy/pre_upgrade_script/ACI-Pre-Upgrade-Validation-Script
collected 7 items                                                                                                                                                                                           

tests/test_logic.py .......                                                                                                                                                                           [100%]

============================================================================================= 7 passed in 0.07s ============================================================================================
```
pytest run output:
```

Starting test_pos_telemetryStatsServerP_object_check
[Check  1/6] telemetryStatsServerP Object Check...                                                                FAIL - OUTAGE WARNING!!
  Current version  Target Version  Warning
  ---------------  --------------  -------
  4.2(1a)          5.2(4d)         telemetryStatsServerP.collectorLocation = "apic" Found

  Recommended Action: Change telemetryStatsServerP.collectorLocation to "none" prior to upgrade
  Reference Document: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCvt47850


[Check  2/6] telemetryStatsServerP Object Check...                                                                                   PASS
[Check  3/6] telemetryStatsServerP Object Check...                                                                FAIL - OUTAGE WARNING!!
  Current version  Target Version  Warning
  ---------------  --------------  -------
  3.2(1a)          5.2(6a)         telemetryStatsServerP.collectorLocation = "apic" Found

  Recommended Action: Change telemetryStatsServerP.collectorLocation to "none" prior to upgrade
  Reference Document: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCvt47850


[Check  4/6] telemetryStatsServerP Object Check...                                                                                   PASS
              

Starting Negative stale_nir_object_check
[Check  1/6] telemetryStatsServerP Object Check...                                                                                   PASS
[Check  2/6] telemetryStatsServerP Object Check...                                                                                   PASS
[Check  3/6] telemetryStatsServerP Object Check...                                                                                   PASS
[Check  4/6] telemetryStatsServerP Object Check...                                                                                   PASS
[Check  5/6] telemetryStatsServerP Object Check...                                                                                   PASS
[Check  6/6] telemetryStatsServerP Object Check... Target version not supplied. Skipping.                           MANUAL CHECK REQUIRED
              Starting test_pos_isis_redis_metric_mpod_msite
```
```