### PR TITLE
Added BGP Route-target Type Check for GOLF over L2EVPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Key:
 | L3Out Route Map import/export direction         | See Pre-Upgrade Checklist | L3Out incorrect route map direction |
 | Intersight Device Connector upgrade status      | Flags if APIC Intersight Connector is upgrading| Intersight Device Connector is upgrading |
 | ISIS Redistribution Metric for MPOD/Msite       | For multi-pod/multi-site deployment, whether isis redistribute metric is less than 63 |Switch Graceful Upgrade Guidelines|
+| BGP Route-target Type for GOLF over L2EVPN	  | For GOLF deployment, whether BGP route-target type starts with route-target: |Switch Graceful Upgrade Guidelines|
 
 ## Defect Condition Checks
 

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -2139,13 +2139,13 @@ def bgp_golf_route_target_type_check(index, total_checks, cversion=None, tversio
                     globalname = ''
                     vrfdn = vrf['fvCtx']['attributes']['dn']
                     for child in vrf['fvCtx']['children']:
-                        if 'l3extGlobalCtxName' in child:
+                        if child.get('l3extGlobalCtxName'):
                             globalname = child['l3extGlobalCtxName']['attributes'].get('name')
-                        elif 'bgpRtTargetP' in child:
-                            for bgprt in child['bgpRtTargetP']['children']:
-                                if 'bgpRtTarget' in bgprt and not bgprt['bgpRtTarget']['attributes']['rt'].startswith('route-target:'):
-                                    if globalname is not '':
-                                        # when globalname is not '', it indicate this vrf is extended to GOLF
+                    if globalname != '':
+                        for child in vrf['fvCtx']['children']:
+                            if child.get('bgpRtTargetP'):
+                                for bgprt in child['bgpRtTargetP']['children']:
+                                    if bgprt.get('bgpRtTarget') and not bgprt['bgpRtTarget']['attributes']['rt'].startswith('route-target:'):
                                         vrf_rt.append((vrfdn,globalname,bgprt['bgpRtTarget']['attributes']['rt']))
 
         if len(vrf_rt) >=1:

--- a/tests/fvCtx.json_pos
+++ b/tests/fvCtx.json_pos
@@ -1,0 +1,53 @@
+{
+    "totalCount": "1",
+    "imdata": [
+        {
+            "fvCtx": {
+                "attributes": {
+                    "annotation": "orchestrator:msc-shadow:no",
+                    "bdEnforcedEnable": "no",
+                    "dn": "uni/tn-welkin/ctx-qa",
+                    "knwMcastAct": "permit",
+                    "monPolDn": "uni/tn-common/monepg-default",
+                    "name": "qa",
+                    "pcEnfDir": "ingress",
+                    "pcEnfDirUpdated": "yes",
+                    "pcEnfPref": "enforced",
+                    "pcTag": "16386",
+                    "scope": "3080192",
+                    "seg": "3080192"
+                },
+                "children": [
+                    {
+                        "l3extGlobalCtxName": {
+                            "attributes": {
+                                "name": "welkinqa",
+                                "rn": "globalctxname"
+                            }
+                        }
+                    },
+                    {
+                        "bgpRtTargetP": {
+                            "attributes": {
+                                "af": "ipv4-ucast",
+                                "rn": "rtp-ipv4-ucast"
+                            },
+                            "children": [
+                                {
+                                    "bgpRtTarget": {
+                                        "attributes": {
+                                            "rn": "rt-[extended:as2-nn2:100:2000]-import",
+                                            "rt": "extended:as2-nn2:100:2000",
+                                            "targetAf": "l2vpn-evpn",
+                                            "type": "import"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -100,6 +100,7 @@ def test_llfc_susceptibility_check(upgradePaths):
         if pathnum == 7:
             assert script.llfc_susceptibility_check(pathnum, pathlen, **testdata) == script.MANUAL
 
+
 def test_pos_telemetryStatsServerP_object_check(upgradePaths):
     script.print_title("Starting test_pos_telemetryStatsServerP_object_check\n")
     pathlen = len(upgradePaths)
@@ -227,8 +228,8 @@ def test_contract_22_defect_check(upgradePaths):
             assert script.contract_22_defect_check(pathnum, pathlen, **testdata) == script.PASS
         if pathnum == 6:
             assert script.contract_22_defect_check(pathnum, pathlen, **testdata) == script.MANUAL
-            
-    
+
+
 def test_pos_internal_vlanpool_check(upgradePaths):
     script.print_title("Starting Positive internal_vlanpool_check\n")
     pathlen = len(upgradePaths)
@@ -248,7 +249,8 @@ def test_pos_internal_vlanpool_check(upgradePaths):
             assert script.internal_vlanpool_check(pathnum, pathlen, **testdata) == script.FAIL_O
         if pathnum == 5:
             assert script.internal_vlanpool_check(pathnum, pathlen, **testdata) == script.PASS
-            
+
+
 def test_neg_internal_vlanpool_check(upgradePaths):
     script.print_title("Starting Negative internal_vlanpool_check\n")
     pathlen = len(upgradePaths)
@@ -269,3 +271,26 @@ def test_neg_internal_vlanpool_check(upgradePaths):
             assert script.internal_vlanpool_check(pathnum, pathlen, **testdata) == script.PASS
         if pathnum == 5:
             assert script.internal_vlanpool_check(pathnum, pathlen, **testdata) == script.PASS
+
+
+def test_bgp_golf_route_target_type_check(upgradePaths):
+    script.print_title("Starting bgp_golf_route_target_type_check tests\n")
+    pathlen = len(upgradePaths)
+    for i, testdata in enumerate(upgradePaths):
+        with open("tests/fvCtx.json_pos","r") as file:
+            testdata.update({"fvCtx.json": json.loads(file.read())['imdata']})
+        pathnum = i+1
+        if pathnum == 1:
+            assert script.bgp_golf_route_target_type_check(pathnum, pathlen, **testdata) == script.PASS
+        if pathnum == 2:
+            assert script.bgp_golf_route_target_type_check(pathnum, pathlen, **testdata) == script.FAIL_O
+        if pathnum == 3:
+            assert script.bgp_golf_route_target_type_check(pathnum, pathlen, **testdata) == script.FAIL_O
+        if pathnum == 4:
+            assert script.bgp_golf_route_target_type_check(pathnum, pathlen, **testdata) == script.PASS
+        if pathnum == 5:
+            assert script.bgp_golf_route_target_type_check(pathnum, pathlen, **testdata) == script.PASS
+        if pathnum == 6:
+            assert script.bgp_golf_route_target_type_check(pathnum, pathlen, **testdata) == script.MANUAL
+        if pathnum == 7:
+            assert script.bgp_golf_route_target_type_check(pathnum, pathlen, **testdata) == script.FAIL_O


### PR DESCRIPTION
Current version 3.2(9h), target version 4.2(7v)
```
Gathering APIC Versions from Firmware Repository...

[1]: aci-apic-dk9.3.2.9h.bin
[2]: aci-apic-dk9.4.2.7v.bin
[3]: aci-apic-dk9.5.2.7f.bin

What is the Target Version?     : 2

You have chosen version "aci-apic-dk9.4.2.7v.bin"
...
[Check 36/42] BGP route target type for GOLF over L2EVPN...                           FAIL - OUTAGE WARNING!!
  VRF DN                Global Name  Route Target               Recommendation
  ------                -----------  ------------               --------------
  uni/tn-welkin/ctx-qa  welkinqa     extended:as2-nn2:100:2000  Reconfigure extended: RT with prefix route-target:

  Reference Document: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCvm23100