### PR TITLE
Make it compatible with both py27 and py38

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -1527,7 +1527,7 @@ def vnid_mismatch_check(index, total_checks, **kwargs):
 
     # Iterate through, check for overlaps, and print
     for key, epg in iteritems(epg_encap_dict):
-        for vlanKey, vlan in epg.iteritems():
+        for vlanKey, vlan in iteritems(epg):
             fab_encap_to_check = ""
             for deployment in vlan:
                 if fab_encap_to_check == "" or deployment["fabEncap"] == fab_encap_to_check:
@@ -1545,7 +1545,7 @@ def vnid_mismatch_check(index, total_checks, **kwargs):
 
     mismatch_hits.sort()
     for epg in mismatch_hits:
-        for access_encap, nodeFabEncaps in epg["epgDeployment"].iteritems():
+        for access_encap, nodeFabEncaps in iteritems(epg["epgDeployment"]):
             for nodeFabEncap in nodeFabEncaps:
                 node_id = nodeFabEncap['node']
                 fabric_encap = nodeFabEncap['fabEncap']

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -1,5 +1,7 @@
 from __future__ import division
 from __future__ import print_function
+from six import iteritems
+from six.moves import input
 from textwrap import TextWrapper
 from getpass import getpass
 from collections import defaultdict
@@ -505,7 +507,7 @@ def icurl(apitype, query):
     cmd = ['icurl', '-gs', uri]
     logging.info('cmd = ' + ' '.join(cmd))
     response = subprocess.check_output(cmd)
-    logging.debug('response: ' + response)
+    logging.debug('response: ' + str(response))
     imdata = json.loads(response)['imdata']
     if imdata and "error" in imdata[0].keys():
         raise Exception('API call failed! Check debug log')
@@ -515,7 +517,7 @@ def icurl(apitype, query):
 
 def get_credentials():
     while True:
-        usr = raw_input('Enter username for APIC login          : ')
+        usr = input('Enter username for APIC login          : ')
         if usr: break
     while True:
         pwd = getpass('Enter password for corresponding User  : ')
@@ -553,7 +555,7 @@ def get_target_version():
 
         version_choice = None
         while version_choice is None:
-            version_choice = raw_input("What is the Target Version?     : ")
+            version_choice = input("What is the Target Version?     : ")
             try:
                 version_choice = int(version_choice)
                 if version_choice < 1 or version_choice > len(repo_list): raise ValueError("")
@@ -647,11 +649,11 @@ def apic_cluster_health_check(index, total_checks, cversion, **kwargs):
     unformatted_data = []
     doc_url = 'ACI Troubleshooting Guide 2nd Edition - http://cs.co/9003ybZ1d'
     print_title(title, index, total_checks)
-    v = re.search(ver_regex, cversion)
-    if v and ((v.group('major1') == 4 and v.group('major2') >= 2) or v.group('major1') >= 5):
-        recommended_action = 'Troubleshoot by running "acidiag cluster" on APIC CLI'
-    else:
+    cv = AciVersion(cversion)
+    if cv.version and cv.older_than("4.2"):
         recommended_action = 'Follow "Initial Fabric Setup" in ACI Troubleshooting Guide 2nd Edition'
+    else:
+        recommended_action = 'Troubleshoot by running "acidiag cluster" on APIC CLI'
 
     dn_regex = node_regex + r'/av/node-(?P<winode>\d)'
     infraWiNodes = icurl('class', 'infraWiNode.json')
@@ -1524,7 +1526,7 @@ def vnid_mismatch_check(index, total_checks, **kwargs):
         epg_encap_dict[epg_dn][access_encap].append({'node': node, 'fabEncap': fab_encap})
 
     # Iterate through, check for overlaps, and print
-    for key, epg in epg_encap_dict.iteritems():
+    for key, epg in iteritems(epg_encap_dict):
         for vlanKey, vlan in epg.iteritems():
             fab_encap_to_check = ""
             for deployment in vlan:
@@ -2575,7 +2577,7 @@ def apic_ca_cert_validation(index, total_checks, **kwargs):
             certreq_out = certreq_proc.communicate()[0].strip()
 
     logging.debug(certreq_out)
-    if '"error":{"attributes"' in certreq_out:
+    if '"error":{"attributes"' in str(certreq_out):
         # Spines can crash on 5.2(6e)+, but APIC CA Certs should be fixed regardless of tver
         data.append([certreq_out])
 

--- a/requirements-py27.txt
+++ b/requirements-py27.txt
@@ -1,0 +1,7 @@
+# Addtional modules installed on APIC versions with py2.7
+pexpect == 2.4  # APIC uses 2.3 which is no longer available in pypi
+ipaddress == 1.0.16
+
+
+# For testing
+pytest

--- a/requirements-py38.txt
+++ b/requirements-py38.txt
@@ -1,0 +1,7 @@
+# Addtional modules installed on APIC versions with py3.8
+six == 1.14
+pexpect == 4.8
+
+
+# For testing
+pytest


### PR DESCRIPTION
Older APIC firmware versions only have py27.
Relatively older APIC firmware versions use py27 as the default. Newer APIC firmware versions use py38 as the default and no longer has py27 at all.
To support any APIC firmware version, make this script compatible with both py27 and py38.