### PR TITLE
Global switch_version attribute created and used by telemetryStatsServerP check

### DIFF
--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -36,7 +36,7 @@ Items                                                        | This Script      
 [g1]: #compatibility-target-aci-version
 [g2]: #compatibility-cimc-version
 [g3]: #compatibility-switch-hardware
-[g4]: #compatibility-switch-hardware-gen1
+[g4]: #compatibility-switch-hardware---gen1
 [g5]: #compatibility-remote-leaf-switch
 [g6]: #apic-target-version-image-and-md5-hash
 [g7]: #apic-cluster-is-fully-fit
@@ -138,7 +138,7 @@ Items                                           | Defect       | This Script    
 [d1]: #ep-announce-compatibility
 [d2]: #eventmgr-db-size
 [d3]: #contract-port-22
-[d4]: #telemetry-stats
+[d4]: #telemetrystatsserverp-object
 [d5]: #link-level-flow-control
 [d6]: #internal-vlan-pool
 [d7]: #apic-ca-cert-validation
@@ -1324,7 +1324,9 @@ Due to the defect CSCvt47850, if the switches are still on an older version than
 To avoid this issue, change the `collectorLocation` type to `none` through the API to prevent the object from being automatically deleted post upgrade.
 
 1. If `telemetryStatsServerP` exists with `collectorLocation="apic"`, use the API to change the `collectorLocation` type to `none`.
+
     !!! example
+        `collectorLocation` is set to `apic` so this fabric is susceptible to CSCvt47850. Use icurl to change `collectorLocation` to `none`.
         ```
         apic# moquery -c telemetryStatsServerP
         # telemetry.StatsServerP
@@ -1339,7 +1341,9 @@ To avoid this issue, change the `collectorLocation` type to `none` through the A
 2. Upgrade both Cisco APICs and switches to the target version.
 
 3. After validating that all switches have been upgraded successfully, delete the `telemetryStatsSeverP` managed object.
+
     !!! example
+        Object can safely be removed from the fabric.
         ```
         apic# bash
         apic:~> icurl -kX POST "http://localhost:7777/api/mo/uni/fabric/servers/stserverp-default.xml" -d '<telemetryStatsServerP status="deleted"/>'

--- a/tests/telemetryStatsServerP_object_check/test_telemetryStatsServerP_object_check.py
+++ b/tests/telemetryStatsServerP_object_check/test_telemetryStatsServerP_object_check.py
@@ -15,7 +15,7 @@ telemetryStatsServerPs = "telemetryStatsServerP.json"
 
 
 @pytest.mark.parametrize(
-    "icurl_outputs, cversion, tversion, expected_result",
+    "icurl_outputs, switch_version, tversion, expected_result",
     [
         (
             {telemetryStatsServerPs: []},
@@ -79,11 +79,11 @@ telemetryStatsServerPs = "telemetryStatsServerP.json"
         ),
     ],
 )
-def test_logic(mock_icurl, cversion, tversion, expected_result):
+def test_logic(mock_icurl, switch_version, tversion, expected_result):
     result = script.telemetryStatsServerP_object_check(
         1,
         1,
-        script.AciVersion(cversion),
+        script.AciVersion(switch_version),
         script.AciVersion(tversion) if tversion else None,
     )
     assert result == expected_result

--- a/tests/telemetryStatsServerP_object_check/test_telemetryStatsServerP_object_check.py
+++ b/tests/telemetryStatsServerP_object_check/test_telemetryStatsServerP_object_check.py
@@ -15,7 +15,7 @@ telemetryStatsServerPs = "telemetryStatsServerP.json"
 
 
 @pytest.mark.parametrize(
-    "icurl_outputs, switch_version, tversion, expected_result",
+    "icurl_outputs, sw_cversion, tversion, expected_result",
     [
         (
             {telemetryStatsServerPs: []},
@@ -79,11 +79,11 @@ telemetryStatsServerPs = "telemetryStatsServerP.json"
         ),
     ],
 )
-def test_logic(mock_icurl, switch_version, tversion, expected_result):
+def test_logic(mock_icurl, sw_cversion, tversion, expected_result):
     result = script.telemetryStatsServerP_object_check(
         1,
         1,
-        script.AciVersion(switch_version),
+        script.AciVersion(sw_cversion),
         script.AciVersion(tversion) if tversion else None,
     )
     assert result == expected_result


### PR DESCRIPTION


```
< 13:44:34 benjwils ./ACI-Pre-Upgrade-Validation-Script/tests/telemetryStatsServerP_object_check> $ pytest -v test_telemetryStatsServerP_object_check.py
====================================================================================================================================== test session starts =======================================================================================================================================
platform darwin -- Python 2.7.18, pytest-4.6.11, py-1.11.0, pluggy-0.13.1 -- /Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python
cachedir: .pytest_cache
rootdir: ./ACI-Pre-Upgrade-Validation-Script, inifile: pytest.ini
collected 10 items

test_telemetryStatsServerP_object_check.py::test_logic[icurl_outputs0-4.2(1b)-5.2(2a)-PASS] PASSED                                                                                                                                                                                         [ 10%]
test_telemetryStatsServerP_object_check.py::test_logic[icurl_outputs1-3.2(1a)-4.2(4d)-PASS] PASSED                                                                                                                                                                                         [ 20%]
test_telemetryStatsServerP_object_check.py::test_logic[icurl_outputs2-3.2(1a)-5.2(6a)-PASS] PASSED                                                                                                                                                                                         [ 30%]
test_telemetryStatsServerP_object_check.py::test_logic[icurl_outputs3-4.2(3a)-4.2(7d)-PASS] PASSED                                                                                                                                                                                         [ 40%]
test_telemetryStatsServerP_object_check.py::test_logic[icurl_outputs4-2.2(3a)-2.2(4r)-PASS] PASSED                                                                                                                                                                                         [ 50%]
test_telemetryStatsServerP_object_check.py::test_logic[icurl_outputs5-5.2(1a)-None-MANUAL CHECK REQUIRED] PASSED                                                                                                                                                                           [ 60%]
test_telemetryStatsServerP_object_check.py::test_logic[icurl_outputs6-4.2(1b)-5.2(2a)-PASS] PASSED                                                                                                                                                                                         [ 70%]
test_telemetryStatsServerP_object_check.py::test_logic[icurl_outputs7-3.2(1a)-4.2(4d)-PASS] PASSED                                                                                                                                                                                         [ 80%]
test_telemetryStatsServerP_object_check.py::test_logic[icurl_outputs8-3.2(1a)-5.2(6a)-FAIL - OUTAGE WARNING!!] PASSED                                                                                                                                                                      [ 90%]
test_telemetryStatsServerP_object_check.py::test_logic[icurl_outputs9-4.2(3a)-4.2(7d)-PASS] PASSED                                                                                                                                                                                         [100%]

=================================================================================================================================== 10 passed in 0.10 seconds ====================================================================================================================================


// Fabric has four switch versions -- lowest version is selected
apic1# moquery -c firmwareRunning | grep "peVer" | sort | uniq
peVer            : 5.2(6e)
peVer            : 5.2(8g)
peVer            : 6.0(2.200)
peVer            : 6.0(3e)

apic1# python upgrade.py
--- omit ---
Gathering Switch Versions from Firmware Repository...5.2(6e)
--- omit ---
```