### PR TITLE
#88 #101 - invalid_fex_rs_check + tests

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -3425,7 +3425,7 @@ def invalid_fex_rs_check(index, total_checks, **kwargs):
     headers = ["FEX ID", "Invalid DN"]
     data = []
     recommended_action = 'Identify if FEX ID in use, then contact TAC for cleanup'
-    doc_url = 'https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations#invalid-fex-dn'
+    doc_url = 'https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations#invalid-fex-fabricpathep-dn-references'
     print_title(title, index, total_checks)
 
 

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -3419,7 +3419,7 @@ def subnet_scope_check(index, total_checks, cversion, **kwargs):
 
 
 def invalid_fex_rs_check(index, total_checks, **kwargs):
-    title = 'Invalid FEX Relation Source Check'
+    title = 'Invalid FEX Relation Source'
     result = PASS
     msg = ''
     headers = ["FEX ID", "Invalid DN"]

--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -152,7 +152,7 @@ Items                                           | Defect       | This Script    
 [VMM Uplink Container with empty Actives][d11]  | CSCvr96408   | :white_check_mark: | :no_entry_sign:           |:no_entry_sign:
 [CoS 3 with Dynamic Packet Prioritization][d12] | CSCwf05073   | :white_check_mark: | :no_entry_sign:           |:no_entry_sign:
 [N9K-C93108TC-FX3P/FX3H Interface Down][d13]    | CSCwh81430   | :white_check_mark: | :no_entry_sign:           |:no_entry_sign:
-[Invalid FEX fabricPathEp DN References][d14]   | CSCwh81430   | :white_check_mark: | :no_entry_sign:           |:no_entry_sign:
+[Invalid FEX fabricPathEp DN References][d14]   | CSCwh68103   | :white_check_mark: | :no_entry_sign:           |:no_entry_sign:
 
 
 [d1]: #ep-announce-compatibility

--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -152,6 +152,8 @@ Items                                           | Defect       | This Script    
 [VMM Uplink Container with empty Actives][d11]  | CSCvr96408   | :white_check_mark: | :no_entry_sign:           |:no_entry_sign:
 [CoS 3 with Dynamic Packet Prioritization][d12] | CSCwf05073   | :white_check_mark: | :no_entry_sign:           |:no_entry_sign:
 [N9K-C93108TC-FX3P/FX3H Interface Down][d13]    | CSCwh81430   | :white_check_mark: | :no_entry_sign:           |:no_entry_sign:
+[Invalid FEX fabricPathEp DN References][d14]   | CSCwh81430   | :white_check_mark: | :no_entry_sign:           |:no_entry_sign:
+
 
 [d1]: #ep-announce-compatibility
 [d2]: #eventmgr-db-size-defect-susceptibility
@@ -166,6 +168,7 @@ Items                                           | Defect       | This Script    
 [d11]: #vmm-uplink-container-with-empty-actives
 [d12]: #cos-3-with-dynamic-packet-prioritization
 [d13]: #n9k-c93108tc-fx3pfx3h-interface-down
+[d14]: #invalid-fex-fabricpathep-dn-references
 
 
 ## General Check Details
@@ -1797,6 +1800,17 @@ The problem is related only to the front-panel interfaces Ethernet 1/1- 1/48. Op
 Because of this, the target version of your upgrade must be a version with a fix of CSCwh81430 when your fabric includes those switches mentioned above. See the Field Notice [FN74085][20] for details.
 
 
+### Invalid FEX fabricPathEp DN References
+
+If you have deployed a FEX on a version prior to having validations introduced in [CSCwh68103][22], it is possible that `fabricPathEp` objects were created with an incorrect DN format. As a result, the related `infraRsHPathAtt` objects pointing to those `fabricPathEp` will also contain the invalid DN in their DN formatting given how ACI builds out object relations.
+
+Having these invalid DNs and then upgrading to a version that has the validations introduced in [CSCwh68103][22] will result in validation failures while trying to make changes to access policies, blocking new config from being accepted. The validation failure will present itself with the text `Failed to decode IfIndex, id: 0x.......`.
+
+If invalid DNs are found, first identify if the FEX IDs are still in use in case a window needs to be planned. If not in use, delete the `infraRsHPathAtt` objects having an invalid DN. 
+
+This check queries `infraRsHPathAtt` objects related to eths, then check if any have DNs which are incorrectly formatted.
+
+
 
 [0]: https://github.com/datacenter/ACI-Pre-Upgrade-Validation-Script
 [1]: https://www.cisco.com/c/dam/en/us/td/docs/Website/datacenter/apicmatrix/index.html
@@ -1820,3 +1834,4 @@ Because of this, the target version of your upgrade must be a version with a fix
 [19]: https://www.cisco.com/c/en/us/td/docs/dcn/aci/apic/5x/security-configuration/cisco-apic-security-configuration-guide-release-52x/https-access-52x.html
 [20]: https://www.cisco.com/c/en/us/support/docs/field-notices/740/fn74085.html
 [21]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCvv30303
+[22]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwh68103

--- a/tests/invalid_fex_rs_check/infraRsHPathAtt_neg.json
+++ b/tests/invalid_fex_rs_check/infraRsHPathAtt_neg.json
@@ -1,0 +1,46 @@
+[
+  {
+      "infraRsHPathAtt": {
+          "attributes": {
+              "annotation": "",
+              "childAction": "",
+              "dn": "uni/infra/hpaths-105_eth198_1_7/rsHPathAtt-[topology/pod-1/paths-105/extpaths-198/pathep-[eth1/7]]",
+              "extMngdBy": "",
+              "forceResolve": "yes",
+              "lcOwn": "local",
+              "modTs": "2021-10-23T08:33:12.722+09:00",
+              "rType": "mo",
+              "state": "unformed",
+              "stateQual": "none",
+              "status": "",
+              "tCl": "fabricPathEp",
+              "tDn": "topology/pod-1/paths-105/extpaths-198/pathep-[eth1/7]",
+              "tType": "mo",
+              "uid": "15374",
+              "userdom": ""
+          }
+      }
+  },
+  {
+      "infraRsHPathAtt": {
+          "attributes": {
+              "annotation": "",
+              "childAction": "",
+              "dn": "uni/infra/hpaths-__ui_l101_eth1--1/rsHPathAtt-[topology/pod-1/paths-101/pathep-[eth1/1]]",
+              "extMngdBy": "",
+              "forceResolve": "yes",
+              "lcOwn": "local",
+              "modTs": "2018-06-04T08:10:52.124+09:00",
+              "rType": "mo",
+              "state": "unformed",
+              "stateQual": "none",
+              "status": "",
+              "tCl": "fabricPathEp",
+              "tDn": "topology/pod-1/paths-101/pathep-[eth1/1]",
+              "tType": "mo",
+              "uid": "15374",
+              "userdom": ""
+          }
+      }
+  }
+]

--- a/tests/invalid_fex_rs_check/infraRsHPathAtt_pos.json
+++ b/tests/invalid_fex_rs_check/infraRsHPathAtt_pos.json
@@ -1,0 +1,46 @@
+[
+  {
+      "infraRsHPathAtt": {
+          "attributes": {
+              "annotation": "",
+              "childAction": "",
+              "dn": "uni/infra/hpaths-105_eth198_1_7/rsHPathAtt-[topology/pod-1/paths-105/pathep-[eth198/1/7]]",
+              "extMngdBy": "",
+              "forceResolve": "yes",
+              "lcOwn": "local",
+              "modTs": "2021-10-23T08:33:12.722+09:00",
+              "rType": "mo",
+              "state": "unformed",
+              "stateQual": "none",
+              "status": "",
+              "tCl": "fabricPathEp",
+              "tDn": "topology/pod-1/paths-105/pathep-[eth198/1/7]",
+              "tType": "mo",
+              "uid": "15374",
+              "userdom": ""
+          }
+      }
+  },
+  {
+      "infraRsHPathAtt": {
+          "attributes": {
+              "annotation": "",
+              "childAction": "",
+              "dn": "uni/infra/hpaths-__ui_l101_eth1--1/rsHPathAtt-[topology/pod-1/paths-101/pathep-[eth1/1]]",
+              "extMngdBy": "",
+              "forceResolve": "yes",
+              "lcOwn": "local",
+              "modTs": "2018-06-04T08:10:52.124+09:00",
+              "rType": "mo",
+              "state": "unformed",
+              "stateQual": "none",
+              "status": "",
+              "tCl": "fabricPathEp",
+              "tDn": "topology/pod-1/paths-101/pathep-[eth1/1]",
+              "tType": "mo",
+              "uid": "15374",
+              "userdom": ""
+          }
+      }
+  }
+]

--- a/tests/invalid_fex_rs_check/test_invalid_fex_rs_check.py
+++ b/tests/invalid_fex_rs_check/test_invalid_fex_rs_check.py
@@ -1,0 +1,33 @@
+import os
+import pytest
+import logging
+import importlib
+from helpers.utils import read_data
+
+script = importlib.import_module("aci-preupgrade-validation-script")
+
+log = logging.getLogger(__name__)
+dir = os.path.dirname(os.path.abspath(__file__))
+
+
+# icurl queries
+hpath_api =  'infraRsHPathAtt.json?query-target-filter=wcard(infraRsHPathAtt.dn,"eth")'
+
+
+@pytest.mark.parametrize(
+    "icurl_outputs, expected_result",
+    [
+        (
+            {hpath_api: read_data(dir, "infraRsHPathAtt_pos.json")},
+            script.FAIL_UF,
+        ),
+        (
+            {hpath_api: read_data(dir, "infraRsHPathAtt_neg.json")},
+            script.PASS,
+        ),
+
+    ],
+)
+def test_logic(mock_icurl, expected_result):
+    result = script.invalid_fex_rs_check(1, 1)
+    assert result == expected_result


### PR DESCRIPTION
Integration test passed, will work on documentation.

local pytest output:
```
[Check  1/1] Invalid FEX Relation Source Check...                                                                FAIL - UPGRADE FAILURE!!
  FEX ID  Invalid DN
  ------  ----------
  198     uni/infra/hpaths-105_eth198_1_7/rsHPathAtt-[topology/pod-1/paths-105/pathep-[eth198/1/7]]

  Recommended Action: Identify if FEX ID in use, then contact TAC for cleanup
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations#invalid-fex-dn


[Check  1/1] Invalid FEX Relation Source Check...                                                                                    PASS
```