### PR TITLE
#87 CIMC check clarifications around multi-step upgrades and RNE differences

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -2343,10 +2343,10 @@ def cimc_compatibilty_check(index, total_checks, tversion, **kwargs):
     title = 'APIC CIMC Compatibility'
     result = FAIL_UF
     msg = ''
-    headers = ["Node ID", "Current CIMC version", "Minimum Recommended CIMC Version"]
+    headers = ["Node ID", "Model", "Current CIMC version", "Catalog Recommended CIMC Version", "Warning"]
     data = []
-    recommended_action = 'Plan to upgrade CIMC version prior to APIC upgrade'
-    doc_url = '"Compatibility (CIMC Versions)" from Pre-Upgrade Checklists'
+    recommended_action = 'Check Release note of APIC Model/version for latest recommendations.'
+    doc_url = 'https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#compatibility-cimc-version'
     print_title(title, index, total_checks)
     apic_obj = icurl('class', 'eqptCh.json?query-target-filter=wcard(eqptCh.descr,"APIC")')
     if apic_obj and tversion:
@@ -2360,12 +2360,13 @@ def cimc_compatibilty_check(index, total_checks, tversion, **kwargs):
                                        "/rssuppHw-[uni/fabric/compcat-default/ctlrhw-" + model + "].json"
                     compatMo = icurl('mo', compat_lookup_dn)
                     recommended_cimc = compatMo[0]['compatRsSuppHw']['attributes']['cimcVersion']
+                    warning = ""
                     if compatMo and recommended_cimc:
-                        if is_firstver_gt_secondver(current_cimc, recommended_cimc):
-                            pass
-                        else:
+                        if not is_firstver_gt_secondver(current_cimc, "3.0(3a)"):
+                            warning = "Multi-step Upgrade may be required, check UCS CIMC Matrix."
+                        if not is_firstver_gt_secondver(current_cimc, recommended_cimc):
                             nodeid = eqptCh['eqptCh']['attributes']['dn'].split('/')[2]
-                            data.append([nodeid, current_cimc, recommended_cimc])
+                            data.append([nodeid, apic_model, current_cimc, recommended_cimc, warning])
 
             if not data:
                 result = PASS

--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -179,9 +179,12 @@ The script performs the equivalent check by querying objects `compatRsUpgRel`.
 
 ### Compatibility (CIMC Version)
 
-The [APIC Upgrade/Downgrade Support Matrix][1] should be checked for the supported UCS HUU version for your target Cisco APIC version to make sure all server components are running the version from the supported HUU bundle.
+The script checks the minimum recommended CIMC version for the given APIC model on the target version by querying `compatRsSuppHw` objects.
 
-The script checks the minimum recommended CIMC version for the given APIC model on the target version by querying objects `compatRsSuppHw`.
+As the `compatRsSuppHw` object recommendation is strictly tied to the target software image, it is possible that the [Release Note Documentation][4] for your model/target version has a different recommendation than what the software recommends. Always check the release note of your Target version and APIC model to ensure you are getting the latest recommendations.
+
+!!! note
+    Older versions of CIMC may required multi-step CIMC upgrades to get to the identified target version. Refer to the [Cisco UCS Rack Server Upgrade Matrix][22] for the latest documentation on which steps are required and support given your current and target CIMC versions.
 
 ### Compatibility (Switch Hardware)
 
@@ -1820,3 +1823,4 @@ Because of this, the target version of your upgrade must be a version with a fix
 [19]: https://www.cisco.com/c/en/us/td/docs/dcn/aci/apic/5x/security-configuration/cisco-apic-security-configuration-guide-release-52x/https-access-52x.html
 [20]: https://www.cisco.com/c/en/us/support/docs/field-notices/740/fn74085.html
 [21]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCvv30303
+[22]: https://www.cisco.com/c/dam/en/us/td/docs/unified_computing/ucs/c/sw/CIMC-Upgrade-Downgrade-Matrix/index.html

--- a/tests/cimc_compatibilty_check/compatRsSuppHw_605_L2.json
+++ b/tests/cimc_compatibilty_check/compatRsSuppHw_605_L2.json
@@ -1,0 +1,10 @@
+[
+  {
+      "compatRsSuppHw": {
+          "attributes": {
+              "cimcVersion": "4.0(2f)",
+              "dn": "uni/fabric/compcat-default/ctlrfw-apic-6.0(5)/rssuppHw-[uni/fabric/compcat-default/ctlrhw-apicl2]"
+          }
+      }
+  }
+]

--- a/tests/cimc_compatibilty_check/compatRsSuppHw_605_M1.json
+++ b/tests/cimc_compatibilty_check/compatRsSuppHw_605_M1.json
@@ -1,0 +1,10 @@
+[
+  {
+      "compatRsSuppHw": {
+          "attributes": {
+              "cimcVersion": "3.0(4j)",
+              "dn": "uni/fabric/compcat-default/ctlrfw-apic-6.0(5)/rssuppHw-[uni/fabric/compcat-default/ctlrhw-apicm1]"
+          }
+      }
+  }
+]

--- a/tests/cimc_compatibilty_check/eqptCh_newver.json
+++ b/tests/cimc_compatibilty_check/eqptCh_newver.json
@@ -1,0 +1,40 @@
+[
+  {
+      "eqptCh": {
+          "attributes": {
+              "bootSource": "bootflash",
+              "cimcVersion": "4.0(2f)",
+              "configRole": "unspecified",
+              "descr": "APIC-SERVER-L2",
+              "dn": "topology/pod-1/node-1/sys/ch",
+              "hybridMode": "no",
+              "model": "APIC-SERVER-L2"
+          }
+      }
+  },
+  {
+      "eqptCh": {
+          "attributes": {
+              "bootSource": "bootflash",
+              "cimcVersion": "4.0(2f)",
+              "descr": "APIC-SERVER-L2",
+              "dn": "topology/pod-1/node-2/sys/ch",
+              "hybridMode": "no",
+              "model": "APIC-SERVER-L2"
+          }
+      }
+  },
+  {
+      "eqptCh": {
+          "attributes": {
+              "bootSource": "bootflash",
+              "cimcVersion": "4.0(2f)",
+              "configRole": "unspecified",
+              "descr": "APIC-SERVER-M1",
+              "dn": "topology/pod-2/node-3/sys/ch",
+              "hybridMode": "no",
+              "model": "APIC-SERVER-M1"
+          }
+      }
+  }
+]

--- a/tests/cimc_compatibilty_check/eqptCh_oldver.json
+++ b/tests/cimc_compatibilty_check/eqptCh_oldver.json
@@ -1,0 +1,40 @@
+[
+  {
+      "eqptCh": {
+          "attributes": {
+              "bootSource": "bootflash",
+              "cimcVersion": "3.0(4l)",
+              "configRole": "unspecified",
+              "descr": "APIC-SERVER-L2",
+              "dn": "topology/pod-1/node-1/sys/ch",
+              "hybridMode": "no",
+              "model": "APIC-SERVER-L2"
+          }
+      }
+  },
+  {
+      "eqptCh": {
+          "attributes": {
+              "bootSource": "bootflash",
+              "cimcVersion": "3.0(4l)",
+              "descr": "APIC-SERVER-L2",
+              "dn": "topology/pod-1/node-2/sys/ch",
+              "hybridMode": "no",
+              "model": "APIC-SERVER-L2"
+          }
+      }
+  },
+  {
+      "eqptCh": {
+          "attributes": {
+              "bootSource": "bootflash",
+              "cimcVersion": "3.0(4l)",
+              "configRole": "unspecified",
+              "descr": "APIC-SERVER-M1",
+              "dn": "topology/pod-2/node-3/sys/ch",
+              "hybridMode": "no",
+              "model": "APIC-SERVER-M1"
+          }
+      }
+  }
+]

--- a/tests/cimc_compatibilty_check/eqptCh_reallyoldver.json
+++ b/tests/cimc_compatibilty_check/eqptCh_reallyoldver.json
@@ -1,0 +1,40 @@
+[
+  {
+      "eqptCh": {
+          "attributes": {
+              "bootSource": "bootflash",
+              "cimcVersion": "1.5(4e)",
+              "configRole": "unspecified",
+              "descr": "APIC-SERVER-L2",
+              "dn": "topology/pod-1/node-1/sys/ch",
+              "hybridMode": "no",
+              "model": "APIC-SERVER-L2"
+          }
+      }
+  },
+  {
+      "eqptCh": {
+          "attributes": {
+              "bootSource": "bootflash",
+              "cimcVersion": "1.5(4e)",
+              "descr": "APIC-SERVER-L2",
+              "dn": "topology/pod-1/node-2/sys/ch",
+              "hybridMode": "no",
+              "model": "APIC-SERVER-L2"
+          }
+      }
+  },
+  {
+      "eqptCh": {
+          "attributes": {
+              "bootSource": "bootflash",
+              "cimcVersion": "1.5(4e)",
+              "configRole": "unspecified",
+              "descr": "APIC-SERVER-M1",
+              "dn": "topology/pod-2/node-3/sys/ch",
+              "hybridMode": "no",
+              "model": "APIC-SERVER-M1"
+          }
+      }
+  }
+]

--- a/tests/cimc_compatibilty_check/test_cimc_compatibilty_check.py
+++ b/tests/cimc_compatibilty_check/test_cimc_compatibilty_check.py
@@ -1,0 +1,47 @@
+import os
+import pytest
+import logging
+import importlib
+from helpers.utils import read_data
+
+script = importlib.import_module("aci-preupgrade-validation-script")
+
+log = logging.getLogger(__name__)
+dir = os.path.dirname(os.path.abspath(__file__))
+
+
+# icurl queries
+eqptCh_api =  'eqptCh.json?query-target-filter=wcard(eqptCh.descr,"APIC")'
+
+compatRsSuppHwL2_api = 'uni/fabric/compcat-default/ctlrfw-apic-6.0(5)/rssuppHw-[uni/fabric/compcat-default/ctlrhw-apicl2].json'
+compatRsSuppHwM1_api = 'uni/fabric/compcat-default/ctlrfw-apic-6.0(5)/rssuppHw-[uni/fabric/compcat-default/ctlrhw-apicm1].json'
+
+@pytest.mark.parametrize(
+    "icurl_outputs, tversion, expected_result",
+    [
+        (
+            {eqptCh_api: read_data(dir, "eqptCh_reallyoldver.json"),
+            compatRsSuppHwL2_api: read_data(dir, "compatRsSuppHw_605_L2.json"),
+            compatRsSuppHwM1_api: read_data(dir, "compatRsSuppHw_605_M1.json")},
+            "6.0(5a)",
+            script.FAIL_UF,
+        ),
+        (
+            {eqptCh_api: read_data(dir, "eqptCh_oldver.json"),
+            compatRsSuppHwL2_api: read_data(dir, "compatRsSuppHw_605_L2.json"),
+            compatRsSuppHwM1_api: read_data(dir, "compatRsSuppHw_605_M1.json")},
+            "6.0(5a)",
+            script.FAIL_UF,
+        ),
+        (
+            {eqptCh_api: read_data(dir, "eqptCh_newver.json"),
+            compatRsSuppHwL2_api: read_data(dir, "compatRsSuppHw_605_L2.json"),
+            compatRsSuppHwM1_api: read_data(dir, "compatRsSuppHw_605_M1.json")},
+            "6.0(5a)",
+            script.PASS,
+        ),
+    ],
+)
+def test_logic(mock_icurl, tversion, expected_result):
+    result = script.cimc_compatibilty_check(1, 1, script.AciVersion(tversion))
+    assert result == expected_result


### PR DESCRIPTION
## Script changes
1. Update check to flag is CIMC is an old version and may need multi-step CIM Cupgrade
2. Update link to mkdoc
3. Update action to vet RNE

## Doc changes
1. Removed link to APIC matrix, as it looks like it no longer calls out CIMC
2. clarified why RNE should be vetted, regardless of check
3. Added link to UCS CIMC matrix