### PR TITLE
BUG: ssh fails when using commandline HostKeyAlgorithms=+ssh-dss argument

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -180,7 +180,6 @@ class Connection(object):
             logging.debug(
                 "spawning new pexpect connection: ssh %s@%s -p %d" % (self.username, self.hostname, self.port))
             no_verify = " -o StrictHostKeyChecking=no -o LogLevel=ERROR -o UserKnownHostsFile=/dev/null"
-            no_verify += " -o HostKeyAlgorithms=+ssh-dss"
             if self.verify: no_verify = ""
             self.child = pexpect.spawn("ssh %s %s@%s -p %d" % (no_verify, self.username, self.hostname, self.port),
                                        searchwindowsize=self.searchwindowsize)


### PR DESCRIPTION
On certain versions of 5.2.x the OpenSSL version does not support the key algorithm ssh-dss. 

The commandline argument "HostKeyAlgorithms=+ssh-dss" overrides the /etc/ssh/ssh_config argument "HostkeyAlgorithms +ssh-rsa". Because ssh-rsa is not enabled, the script cannot negotiate any key algorithm and the login fails.

Since ssh-dss is no longer considered secure I have removed this argument from the script and we can instead rely on the default settings under /etc/ssh/ssh_config.

Example of failure prior to removal of ssh-dss:
```
# /bin/ssh -vvvo StrictHostKeyChecking=no -o LogLevel=ERROR -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss admin@{IP ADDRESS} -p 22
...
debug1: kex: host key algorithm: (no match)
Unable to negotiate with {IP ADDRESS} port 22: no matching host key type found. Their offer: ssh-rsa
```