### PR TITLE
invalid_fex_rs_check; check fex_ id >= 101

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -3491,7 +3491,7 @@ def invalid_fex_rs_check(index, total_checks, **kwargs):
 
     for rs in infraRsHPathAtt:
         dn = rs["infraRsHPathAtt"]["attributes"]["dn"]
-        m = re.search(r'eth(?P<fex>\d{3,4})\/\d\/\d', dn)
+        m = re.search(r'eth(?P<fex>\d{3})\/\d\/\d', dn)
         if m:
             fex_id = m.group('fex')
             if int(fex_id) >= 101:

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -3491,10 +3491,11 @@ def invalid_fex_rs_check(index, total_checks, **kwargs):
 
     for rs in infraRsHPathAtt:
         dn = rs["infraRsHPathAtt"]["attributes"]["dn"]
-        m = re.search(r'eth(?P<fex>\d+)\/\d\/\d', dn)
+        m = re.search(r'eth(?P<fex>\d{3,4})\/\d\/\d', dn)
         if m:
             fex_id = m.group('fex')
-            data.append([fex_id, dn])
+            if int(fex_id) >= 101:
+                data.append([fex_id, dn])
 
     if data:
         result = FAIL_UF

--- a/tests/invalid_fex_rs_check/infraRsHPathAtt_neg.json
+++ b/tests/invalid_fex_rs_check/infraRsHPathAtt_neg.json
@@ -64,5 +64,27 @@
             "userdom": ""
         }
     }
+  },
+  {
+    "infraRsHPathAtt": {
+        "attributes": {
+            "annotation": "",
+            "childAction": "",
+            "dn": "uni/infra/hpaths-105_eth198_1_7/rsHPathAtt-[topology/pod-1/paths-105/pathep-[eth1/30/11]]",
+            "extMngdBy": "",
+            "forceResolve": "yes",
+            "lcOwn": "local",
+            "modTs": "2021-10-23T08:33:12.722+09:00",
+            "rType": "mo",
+            "state": "unformed",
+            "stateQual": "none",
+            "status": "",
+            "tCl": "fabricPathEp",
+            "tDn": "topology/pod-1/paths-105/pathep-[eth198/1/7]",
+            "tType": "mo",
+            "uid": "15374",
+            "userdom": ""
+        }
+    }
   }
 ]

--- a/tests/invalid_fex_rs_check/infraRsHPathAtt_neg.json
+++ b/tests/invalid_fex_rs_check/infraRsHPathAtt_neg.json
@@ -42,5 +42,27 @@
               "userdom": ""
           }
       }
+  },
+  {
+    "infraRsHPathAtt": {
+        "attributes": {
+            "annotation": "",
+            "childAction": "",
+            "dn": "uni/infra/hpaths-105_eth198_1_7/rsHPathAtt-[topology/pod-1/paths-105/pathep-[eth100/1/7]]",
+            "extMngdBy": "",
+            "forceResolve": "yes",
+            "lcOwn": "local",
+            "modTs": "2021-10-23T08:33:12.722+09:00",
+            "rType": "mo",
+            "state": "unformed",
+            "stateQual": "none",
+            "status": "",
+            "tCl": "fabricPathEp",
+            "tDn": "topology/pod-1/paths-105/pathep-[eth198/1/7]",
+            "tType": "mo",
+            "uid": "15374",
+            "userdom": ""
+        }
+    }
   }
 ]

--- a/tests/invalid_fex_rs_check/infraRsHPathAtt_pos.json
+++ b/tests/invalid_fex_rs_check/infraRsHPathAtt_pos.json
@@ -42,5 +42,27 @@
               "userdom": ""
           }
       }
+  },
+  {
+    "infraRsHPathAtt": {
+        "attributes": {
+            "annotation": "",
+            "childAction": "",
+            "dn": "uni/infra/hpaths-105_eth198_1_7/rsHPathAtt-[topology/pod-1/paths-105/pathep-[eth13/1/7]]",
+            "extMngdBy": "",
+            "forceResolve": "yes",
+            "lcOwn": "local",
+            "modTs": "2021-10-23T08:33:12.722+09:00",
+            "rType": "mo",
+            "state": "unformed",
+            "stateQual": "none",
+            "status": "",
+            "tCl": "fabricPathEp",
+            "tDn": "topology/pod-1/paths-105/pathep-[eth198/1/7]",
+            "tType": "mo",
+            "uid": "15374",
+            "userdom": ""
+        }
+    }
   }
 ]

--- a/tests/invalid_fex_rs_check/infraRsHPathAtt_pos.json
+++ b/tests/invalid_fex_rs_check/infraRsHPathAtt_pos.json
@@ -22,6 +22,28 @@
       }
   },
   {
+    "infraRsHPathAtt": {
+        "attributes": {
+            "annotation": "",
+            "childAction": "",
+            "dn": "uni/infra/hpaths-105_eth198_1_7/rsHPathAtt-[topology/pod-1/paths-105/pathep-[eth101/1/20]]",
+            "extMngdBy": "",
+            "forceResolve": "yes",
+            "lcOwn": "local",
+            "modTs": "2021-10-23T08:33:12.722+09:00",
+            "rType": "mo",
+            "state": "unformed",
+            "stateQual": "none",
+            "status": "",
+            "tCl": "fabricPathEp",
+            "tDn": "topology/pod-1/paths-105/pathep-[eth198/1/7]",
+            "tType": "mo",
+            "uid": "15374",
+            "userdom": ""
+        }
+    }
+},
+  {
       "infraRsHPathAtt": {
           "attributes": {
               "annotation": "",
@@ -48,7 +70,29 @@
         "attributes": {
             "annotation": "",
             "childAction": "",
-            "dn": "uni/infra/hpaths-105_eth198_1_7/rsHPathAtt-[topology/pod-1/paths-105/pathep-[eth13/1/7]]",
+            "dn": "uni/infra/hpaths-105_eth198_1_7/rsHPathAtt-[topology/pod-1/paths-105/pathep-[eth13/1/4]]",
+            "extMngdBy": "",
+            "forceResolve": "yes",
+            "lcOwn": "local",
+            "modTs": "2021-10-23T08:33:12.722+09:00",
+            "rType": "mo",
+            "state": "unformed",
+            "stateQual": "none",
+            "status": "",
+            "tCl": "fabricPathEp",
+            "tDn": "topology/pod-1/paths-105/pathep-[eth198/1/7]",
+            "tType": "mo",
+            "uid": "15374",
+            "userdom": ""
+        }
+    }
+  },
+  {
+    "infraRsHPathAtt": {
+        "attributes": {
+            "annotation": "",
+            "childAction": "",
+            "dn": "uni/infra/hpaths-105_eth198_1_7/rsHPathAtt-[topology/pod-1/paths-105/pathep-[eth1/11/11]]",
             "extMngdBy": "",
             "forceResolve": "yes",
             "lcOwn": "local",


### PR DESCRIPTION
local pytest success:
```
[Check  1/1] Invalid FEX Relation Source...                                                                      FAIL - UPGRADE FAILURE!!
  FEX ID  Invalid DN
  ------  ----------
  198     uni/infra/hpaths-105_eth198_1_7/rsHPathAtt-[topology/pod-1/paths-105/pathep-[eth198/1/7]]

  Recommended Action: Identify if FEX ID in use, then contact TAC for cleanup
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations#invalid-fex-fabricpathep-dn-references


[Check  1/1] Invalid FEX Relation Source...                                                                                          PASS

```

Check is now only flagged if regex returned fex_id is >= 101.