### PR TITLE
add new hw rev + tver check

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -2901,7 +2901,7 @@ def sup_hwrev_check(index, total_checks, cversion, tversion, **kwargs):
     headers = ["Pod", "Node", "Sup Slot", "Part Number"]
     data = []
     recommended_action = "Consider changing target version to a fixed release from CSCwf44222"
-    doc_url = 'https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwb86706'
+    doc_url = 'https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#spine-sup-hw-revision'
 
     print_title(title, index, total_checks)
 

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -2894,19 +2894,18 @@ def fabricdomain_name_check(index, total_checks, cversion, tversion, **kwargs):
     return result
 
 
-# TODO: Add tversion handling when CSCwb86706 is fixed.
 def sup_hwrev_check(index, total_checks, cversion, tversion, **kwargs):
     title = 'Spine SUP HW Revision'
     result = FAIL_O
     msg = ''
     headers = ["Pod", "Node", "Sup Slot", "Part Number"]
     data = []
-    recommended_action = "Do not upgrade yet. Contact TAC and share these results."
+    recommended_action = "Consider changing target version to a fixed release from CSCwf44222"
     doc_url = 'https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwb86706'
 
     print_title(title, index, total_checks)
 
-    if cversion.newer_than("5.2(1a)") and cversion.older_than("6.0(1a)"):
+    if cversion.newer_than("5.2(1a)") and cversion.older_than("6.0(1a)") and tversion.older_than("5.2(8f)") or (tversion.major1 == "6" and tversion.older_than("6.0(3d)")):
         sup_re = r'/.+(?P<supslot>supslot-\d+)'
         sups = icurl('class', 'eqptSpCmnBlk.json?&query-target-filter=wcard(eqptSpromSupBlk.dn,"sup")')
         if not sups:
@@ -2915,7 +2914,7 @@ def sup_hwrev_check(index, total_checks, cversion, tversion, **kwargs):
 
         for sup in sups:
             prtNum = sup['eqptSpCmnBlk']['attributes']['prtNum']
-            if prtNum in ['73-18562-02', '73-18570-02']:
+            if prtNum in ['73-18562-02', '73-18570-02', '73-18570-03']:
                 dn = re.search(node_regex+sup_re, sup['eqptSpCmnBlk']['attributes']['dn'])
                 pod_id = dn.group("pod")
                 node_id = dn.group("node")

--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -150,7 +150,7 @@ Items                                           | Defect       | This Script    
 [Internal VLAN Pool Check][d6]                  | CSCvw33061   | :white_check_mark: | :no_entry_sign:           |:white_check_mark:
 [APIC CA Cert Validation][d7]                   | CSCvy35257   | :white_check_mark: | :no_entry_sign:           |:no_entry_sign:
 [FabricDomain Name Check][d8]                   | CSCwf80352   | :white_check_mark: | :no_entry_sign:           |:no_entry_sign:
-[Spine SUP HW Revision Check][d9]               | CSCwb86706   | :white_check_mark: | :no_entry_sign:           |:no_entry_sign:
+[Spine SUP HW Revision][d9]                     | CSCwb86706   | :white_check_mark: | :no_entry_sign:           |:no_entry_sign:
 [SUP-A/A+ High Memory Usage][d10]               | CSCwh39489   | :white_check_mark: | :no_entry_sign:           |:no_entry_sign:
 [VMM Uplink Container with empty Actives][d11]  | CSCvr96408   | :white_check_mark: | :no_entry_sign:           |:no_entry_sign:
 [CoS 3 with Dynamic Packet Prioritization][d12] | CSCwf05073   | :white_check_mark: | :no_entry_sign:           |:no_entry_sign:
@@ -1782,9 +1782,11 @@ The script checks if the target version is 6.0(2) and if the fabric name contain
 
 ### Spine SUP HW Revision
 
-Due to the defect CSCwb86706, ACI modular spine switches may not be able to boot after an upgrade depending on the hardware revision (part number) of the SUP modules.
+Due to the defect [CSCwb86706][29], ACI modular spine switches may not be able to boot after an upgrade depending on the hardware revision (part number) of the SUP modules.
 
 The script checks if the version and the SUP modules are susceptible to the defect.
+
+If this check is flagged, Known Fixed Releases documented in [CSCwf44222][30] should be assessed as a target image to avoid the defect condition.
 
 ### CoS 3 with Dynamic Packet Prioritization
 
@@ -1965,3 +1967,5 @@ If found, the target version of your upgrade should be a version with a fix for 
 [26]: https://www.cisco.com/c/en/us/td/docs/switches/datacenter/aci/apic/sw/kb/b_Cisco_ACI_and_Forward_Error_Correction.html#Cisco_Reference.dita_5cef69b3-b7fa-4bde-ba60-38129c9e7d82
 [27]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwb91766
 [28]: https://www.cisco.com/c/en/us/td/docs/dcn/aci/apic/all/apic-installation-aci-upgrade-downgrade/Cisco-APIC-Installation-ACI-Upgrade-Downgrade-Guide/m-aci-upgrade-downgrade-architecture.html#Cisco_Reference.dita_22480abb-4138-416b-8dd5-ecde23f707b4
+[29]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwb86706
+[30]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwf44222

--- a/tests/sup_hwrev_check/eqptSpCmnBlk_POS.json
+++ b/tests/sup_hwrev_check/eqptSpCmnBlk_POS.json
@@ -38,5 +38,15 @@
         "prtNum": "73-18570-02"
       }
     }
+  },
+  {
+    "eqptSpCmnBlk": {
+      "attributes": {
+        "dn": "topology/pod-1/node-1203/sys/ch/supslot-1/sup/spsup/spcmn",
+        "oem": "Cisco Systems, Inc.",
+        "pdNum": "N9K-SUP-B",
+        "prtNum": "73-18570-03"
+      }
+    }
   }
 ]

--- a/tests/sup_hwrev_check/test_sup_hwrev_check.py
+++ b/tests/sup_hwrev_check/test_sup_hwrev_check.py
@@ -21,14 +21,21 @@ eqptSpCmnBlk = 'eqptSpCmnBlk.json?&query-target-filter=wcard(eqptSpromSupBlk.dn,
         (
             {eqptSpCmnBlk: read_data(dir, "eqptSpCmnBlk_POS.json")},
             "5.2(1g)",
-            "6.0(2h)",
+            "5.2(8e)",
             script.FAIL_O,
         ),
-        # Affected sups, no longer on 5.2
+        # Affected Sups, going to fixed version
         (
             {eqptSpCmnBlk: read_data(dir, "eqptSpCmnBlk_POS.json")},
-            "6.0(3a)",
-            "6.0(2h)",
+            "5.2(1g)",
+            "5.2(8f)",
+            script.PASS,
+        ),
+        # Affected sups, going to fixed version
+        (
+            {eqptSpCmnBlk: read_data(dir, "eqptSpCmnBlk_POS.json")},
+            "6.0(1a)",
+            "6.0(3d)",
             script.PASS,
         ),
         # affected sups, not yet on 5.2
@@ -42,7 +49,7 @@ eqptSpCmnBlk = 'eqptSpCmnBlk.json?&query-target-filter=wcard(eqptSpromSupBlk.dn,
         (
             {eqptSpCmnBlk: read_data(dir, "eqptSpCmnBlk_NEG.json")},
             "5.2(1g)",
-            "6.0(2h)",
+            "5.2(8e)",
             script.PASS,
         ),
     ],


### PR DESCRIPTION
pytest output:
```
[Check  1/1] Spine SUP HW Revision...                                                                             FAIL - OUTAGE WARNING!!
  Pod  Node  Sup Slot   Part Number
  ---  ----  --------   -----------
  1    1201  supslot-1  73-18562-02
  1    1201  supslot-2  73-18562-02
  1    1202  supslot-1  73-18570-02
  1    1202  supslot-2  73-18570-02
  1    1203  supslot-1  73-18570-03

  Recommended Action: Consider changing target version to a fixed release from CSCwf44222
  Reference Document: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwb86706


[Check  1/1] Spine SUP HW Revision...                                                                                                PASS
[Check  1/1] Spine SUP HW Revision...                                                                                                PASS
[Check  1/1] Spine SUP HW Revision...                                                                                                PASS
[Check  1/1] Spine SUP HW Revision...                                                                                                PASS
```
