### PR TITLE
Add pagination in `icurl()` to support large amount of objects

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,19 +16,65 @@ log = logging.getLogger(__name__)
 @pytest.fixture
 def icurl_outputs():
     """Allows each test function to simulate the responses of icurl() with a
-    test data in the form of { key: value }.
+    test data in the form of { query: test_data }.
 
     where:
-        key = icurl query parameter such as `topSystem.json`
-        value = An expected result of icurl(). Should be the list under
-                `imdata` in the JSON response from APIC.
+        query = icurl query parameter such as `topSystem.json`
+        test_data = An expected result of icurl().
+                    This can take different forms in the test data. See below for details.
 
     If a single check performs multiple icurl quries, provide test data as
     shown below:
     {
-        "query1": "result1",
-        "query2": "result2",
+        "query1": "test_data1",
+        "query2": "test_data2",
     }
+
+    Examples)
+
+    Option 1 - test_data is the content of imdata:
+        {
+            "object_class1.json?filter1=xxx&filter2=yyy": [],
+            "object_class2.json": [{"object_class": {"attributes": {}}}],
+        }
+
+    Option 2 - test_data is the whole response of an API query:
+        {
+            "object_class1.json?filter1=xxx&filter2=yyy": {
+                "totalCount": "0",
+                "imdata": [],
+            },
+            "object_class2.json": {
+                "totalCount": "1",
+                "imdata": [{"object_class": {"attributes": {}}}],
+            }
+        }
+
+    Option 3 - test_data is the bundle of API queries with multiple pages:
+        {
+            "object_class1.json?filter1=xxx&filter2=yyy": [
+                {
+                    "totalCount": "0",
+                    "imdata": [],
+                }
+            ],
+            "object_class2.json": [
+                {
+                    "totalCount": "199000",
+                    "imdata": [
+                        {"object_class": {"attributes": {...}}},
+                        ...
+                    ],
+                },
+                {
+                    "totalCount": "199000",
+                    "imdata": [
+                        {"object_class": {"attributes": {...}}},
+                        ...
+                    ],
+                },
+            ]
+        }
     """
     return {
         "object_class1.json?filter1=xxx&filter2=yyy": [],
@@ -38,21 +84,33 @@ def icurl_outputs():
 
 @pytest.fixture
 def mock_icurl(monkeypatch, icurl_outputs):
-    def _mock_icurl(apitype, query):
-        if icurl_outputs.get(query) is None:
+    def _mock_icurl(apitype, query, page=0, page_size=100000):
+        output = icurl_outputs.get(query)
+        if output is None:
             log.error("Query `%s` not found in test data", query)
-
-        imdata = icurl_outputs.get(query, [])
-        if imdata and "error" in imdata[0]:
-            if "not found in class" in imdata[0]['error']['attributes']['text']:
-                raise script.OldVerPropNotFound('cversion does not have requested property')
-            elif "unresolved class for" in imdata[0]['error']['attributes']['text']:
-                raise script.OldVerClassNotFound('cversion does not have requested class')
-            elif "not found" in imdata[0]['error']['attributes']['text']:
-                raise script.OldVerClassNotFound('cversion does not have requested class')
+            data = {"totalCount": "0", "imdata": []}
+        elif isinstance(output, list):
+            # icurl_outputs option 1 - output is imdata which is empty
+            if not output:
+                data = {"totalCount": "0", "imdata": []}
+            # icurl_outputs option 1 - output is imdata
+            elif output[0].get("totalCount") is None:
+                data = {"totalCount": str(len(output)), "imdata": output}
+            # icurl_outputs option 3 - output is each page of icurl
+            elif len(output) > page:
+                data = output[page]
+            # icurl_outputs option 3 - output is each page of icurl
+            # page after the last page which is empty
             else:
-                raise Exception('API call failed! Check debug log')
-        else:
-            return imdata
+                data = {"totalCount": output[0]["totalCount"], "imdata": []}
+        # icurl_outputs option 2 - output is full response of icurl without pages
+        elif isinstance(output, dict):
+            if page == 0:
+                data = output
+            else:
+                data = {"totalCount": output["totalCount"], "imdata": []}
 
-    monkeypatch.setattr(script, "icurl", _mock_icurl)
+        script._icurl_error_handler(data['imdata'])
+        return data
+
+    monkeypatch.setattr(script, "_icurl", _mock_icurl)

--- a/tests/test_icurl.py
+++ b/tests/test_icurl.py
@@ -1,0 +1,141 @@
+import pytest
+import importlib
+
+script = importlib.import_module("aci-preupgrade-validation-script")
+
+# icurl queries
+fabricNodePEps = "fabricNodePEp.json"
+
+data = [
+    {
+        "fabricNodePEp": {
+            "attributes": {
+                "dn": "uni/fabric/protpol/expgep-101-103/nodepep-101",
+                "id": "101",
+            }
+        }
+    },
+    {
+        "fabricNodePEp": {
+            "attributes": {
+                "dn": "uni/fabric/protpol/expgep-204-206/nodepep-206",
+                "id": "206",
+            }
+        }
+    },
+    {
+        "fabricNodePEp": {
+            "attributes": {
+                "dn": "uni/fabric/protpol/expgep-101-103/nodepep-103",
+                "id": "103",
+            }
+        }
+    },
+    {
+        "fabricNodePEp": {
+            "attributes": {
+                "dn": "uni/fabric/protpol/expgep-204-206/nodepep-204",
+                "id": "204",
+            }
+        }
+    },
+]
+long_data = data * 25000  # 100K entries
+long_data_all = long_data * 2 + data
+
+
+@pytest.mark.parametrize(
+    "apitype, query, icurl_outputs, expected_result",
+    [
+        # option 1: test_data is imdata
+        (
+            "class",
+            "fabricNodePEp.json",
+            {"fabricNodePEp.json": data},
+            data,
+        ),
+        # option 2: test_data is the whole response of an API query (totalCount + imdata)
+        (
+            "class",
+            "fabricNodePEp.json",
+            {"fabricNodePEp.json": {"totalCount": str(len(data)), "imdata": data}},
+            data,
+        ),
+        # option 3: test_data is the bundle of API queries with multiple pages
+        (
+            "class",
+            "fabricNodePEp.json",
+            {
+                "fabricNodePEp.json": [
+                    {  # page 0
+                        "totalCount": str(len(long_data_all)),
+                        "imdata": long_data,
+                    },
+                    {  # page 1
+                        "totalCount": str(len(long_data_all)),
+                        "imdata": long_data,
+                    },
+                    {  # page 2
+                        "totalCount": str(len(long_data_all)),
+                        "imdata": data,
+                    },
+                ]
+            },
+            long_data_all,
+        ),
+    ],
+)
+def test_icurl(mock_icurl, apitype, query, expected_result):
+    assert script.icurl(apitype, query) == expected_result
+
+
+@pytest.mark.parametrize(
+    "imdata, expected_exception",
+    [
+        # /api/class/faultInfo.json?query-target-filter=eq(faultInst.cod,"F2109")
+        (
+            [
+                {
+                    "error": {
+                        "attributes": {
+                            "code": "121",
+                            "text": "Prop 'cod' not found in class 'faultInst' property table",
+                        }
+                    }
+                }
+            ],
+            script.OldVerPropNotFound,
+        ),
+        # /api/class/faultInf.json?query-target-filter=eq(faultInst.code,"F2109")
+        (
+            [
+                {
+                    "error": {
+                        "attributes": {
+                            "code": "400",
+                            "text": "Request failed, unresolved class for faultInf",
+                        }
+                    }
+                }
+            ],
+            script.OldVerClassNotFound,
+        ),
+        # /api/class/faultInfo.json?query-target-filter=eq(faultIns.code,"F2109")
+        (
+            [
+                {
+                    "error": {
+                        "attributes": {
+                            "code": "122",
+                            "text": "class faultIns not found",
+                        }
+                    }
+                }
+            ],
+            script.OldVerClassNotFound,
+        ),
+    ],
+)
+def test_icurl_error_handler(imdata, expected_exception):
+    with pytest.raises(expected_exception):
+        script._icurl_error_handler(imdata)


### PR DESCRIPTION
The current API query example made by `icurl()`:
```
/api/class/fvIfConn.json
```

The new API query example with pagination:
```
/api/class/fvIfConn.json?page=0&page-size=100000
```

With the pagination, the API query in `icurl()` will query up to 100K object instances at a time. If there are more objects to be returned, it will automatically query again with the next page such as `page=1`, `page=2` and so on, then it will concatenate all the  result as a single list so that the output of `icurl()` remains the same regardless of the pagination or not.

This enhancement will fix issue #173 and any other failure due to massive amount of objects to be returned.