### PR TITLE
Remove vnid_mismatch_check

### DIFF
--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -104,7 +104,6 @@ Items                                         | Faults         | This Script    
 ------------------------------------------------------|--------------------|---------------------------|-------------------------------
 [VPC-paired Leaf switches][c1]                        | :white_check_mark: | :white_check_mark: 4.2(4) | :white_check_mark:
 [Overlapping VLAN Pool][c2]                           | :white_check_mark: | :no_entry_sign:           | :white_check_mark:
-[VNID Mismatch][c3]                                   | :white_check_mark: | :no_entry_sign:           | :no_entry_sign:
 [L3Out MTU][c4]                                       | :white_check_mark: | :no_entry_sign:           | :white_check_mark:
 [BGP Peer Profile at node level without Loopback][c5] | :white_check_mark: | :no_entry_sign:           | :white_check_mark:
 [L3Out Route Map import/export direction][c6]         | :white_check_mark: | :no_entry_sign:           | :white_check_mark:
@@ -122,7 +121,6 @@ Items                                         | Faults         | This Script    
 
 [c1]: #vpc-paired-leaf-switches
 [c2]: #overlapping-vlan-pool
-[c3]: #vnid-mismatch
 [c4]: #l3out-mtu
 [c5]: #bgp-peer-profile-at-node-level-without-loopback
 [c6]: #l3out-route-map-importexport-direction
@@ -1616,11 +1614,6 @@ Refer to the following documents to understand how overlapping VLAN pools become
 * [ACI: Common migration issue / Overlapping VLAN pools][11]
 * [Validating Overlapping VLANs in the Cisco APIC Layer 2 Networking Configuration Guide, Release 4.2(x)][12]
 * [VLAN Pool - ACI Best Practice Quick Summary][13]
-
-
-### VNID Mismatch                                  
-
-A VNID mismatch can arise due to an [Overlapping VLAN Pool][c2] situation. This verification is closely tied to the [Overlapping VLAN Pool][c2] scenario, which often leads to problems post-upgrade. Nonetheless, if your fabric is currently experiencing any VNID mismatches, you might encounter the challenges outlined in [Overlapping VLAN Pool][c2] even without undergoing an upgrade. This situation also implies the presence of an overlapping VLAN pool configuration, potentially resulting in a VNID mismatch at a distinct EPG following an upgrade, causing different impact to your traffic.
 
 
 ### L3Out MTU                                      

--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -104,6 +104,7 @@ Items                                         | Faults         | This Script    
 ------------------------------------------------------|--------------------|---------------------------|-------------------------------
 [VPC-paired Leaf switches][c1]                        | :white_check_mark: | :white_check_mark: 4.2(4) | :white_check_mark:
 [Overlapping VLAN Pool][c2]                           | :white_check_mark: | :no_entry_sign:           | :white_check_mark:
+[VNID Mismatch][c3] (deprecated)                      | :warning:          | :no_entry_sign:           | :no_entry_sign:
 [L3Out MTU][c4]                                       | :white_check_mark: | :no_entry_sign:           | :white_check_mark:
 [BGP Peer Profile at node level without Loopback][c5] | :white_check_mark: | :no_entry_sign:           | :white_check_mark:
 [L3Out Route Map import/export direction][c6]         | :white_check_mark: | :no_entry_sign:           | :white_check_mark:
@@ -121,6 +122,7 @@ Items                                         | Faults         | This Script    
 
 [c1]: #vpc-paired-leaf-switches
 [c2]: #overlapping-vlan-pool
+[c3]: #vnid-mismatch
 [c4]: #l3out-mtu
 [c5]: #bgp-peer-profile-at-node-level-without-loopback
 [c6]: #l3out-route-map-importexport-direction
@@ -1614,6 +1616,16 @@ Refer to the following documents to understand how overlapping VLAN pools become
 * [ACI: Common migration issue / Overlapping VLAN pools][11]
 * [Validating Overlapping VLANs in the Cisco APIC Layer 2 Networking Configuration Guide, Release 4.2(x)][12]
 * [VLAN Pool - ACI Best Practice Quick Summary][13]
+
+
+### <del>VNID Mismatch</del>
+
+!!! warning "Deprecated"
+    This check was deprecated and removed as it had not only become redundant after the updates in the [Overlapping VLAN Pool][c2] check but also contained a risk of rainsing a false alarm. See [PR #182](https://github.com/datacenter/ACI-Pre-Upgrade-Validation-Script/pull/182) for details.
+
+<span style="color:lightgray">
+A VNID mismatch can arise due to an [Overlapping VLAN Pool][c2] situation. This verification is closely tied to the [Overlapping VLAN Pool][c2] scenario, which often leads to problems post-upgrade. Nonetheless, if your fabric is currently experiencing any VNID mismatches, you might encounter the challenges outlined in [Overlapping VLAN Pool][c2] even without undergoing an upgrade. This situation also implies the presence of an overlapping VLAN pool configuration, potentially resulting in a VNID mismatch at a distinct EPG following an upgrade, causing different impact to your traffic. 
+</span>
 
 
 ### L3Out MTU                                      

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -30,7 +30,7 @@ markdown_extensions:
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
 
-  # emoji 
+  # emoji
   - pymdownx.emoji:
       emoji_index: !!python/name:pymdownx.emoji.gemoji
       emoji_generator: !!python/name:pymdownx.emoji.to_svg

--- a/tests/overlapping_vlan_pools_check/test_overlapping_vlan_pools_check.py
+++ b/tests/overlapping_vlan_pools_check/test_overlapping_vlan_pools_check.py
@@ -2020,7 +2020,7 @@ params = [
                 "ifpg_name": "IFPG_VPC1",
             },
             {
-                "ifp": "L101",
+                "ifp": "L103",
                 "card": "1",
                 "port": "2",
                 "ifpg_class": "infraAccPortGrp",


### PR DESCRIPTION
`vnid_mismatch_check` was added to complement `overlapping_vlan_pools_check`.

Given the recent update (#155, #162), `vnid_mismatch_check` became redundant, and it has a risk of raising a false alarm (see below for details). Thus, it was decided to be removed.

An example of false alarm from `vnid_mismatch_check`:

```
Node 101 --- EPG A (VLAN 10) --- domain A --- VLAN pool A (VLAN 10)
Node 105 --- EPG A (VLAN 10) --- domain B --- VLAN Pool B (VLAN 10)
```

Note that these two switches are not vPC pair.

This is alerted by `vnid_mismatch_check` because VLAN 10 on node 101 and 105 are assigned a different VNID from respective VLAN pools. However, it's expected and will not cause any issues with an upgrade because the VNID for each node is deterministic and will always be the same even after the upgrade. See the "Example:  good only for a specific use case" in https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#overlapping-vlan-pool for details.

