### PR TITLE
New Validation: vzAny-to-vzAny Service Graph when crossing 5.0 release

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -4149,7 +4149,7 @@ def vzany_vzany_service_epg_check(index, total_checks, cversion, tversion, **kwa
     headers = ["Potential Defect", "Reason"]
     data = []
     recommended_action = 'Review Software Advisory for details'
-    doc_url = 'Cisco Software Advisory Notices for CSCwk228974 - http://cs.co/9007yh22H'
+    doc_url = 'Cisco Software Advisory Notices for CSCwh75475 - https://cdetsng.cisco.com/summary/#/defect/CSCwh75475/note?noteTitle=Release-note'
     print_title(title, index, total_checks)
 
     if not tversion:
@@ -4165,7 +4165,7 @@ def vzany_vzany_service_epg_check(index, total_checks, cversion, tversion, **kwa
                 # check if there is vzAny-vzAny configuration associated with this contract
                 vzBrCP_name_regex = r'brc-(?P<brc_name>[^/]+)'
                 match = re.search(vzBrCP_name_regex, vzRsSubjGraphAtt['vzRsSubjGraphAtt']['attributes']['dn'])
-                
+
                 if match:
                     vzBrCP_name = match.group('brc_name')
                     vzBrCP_api =  'vzBrCP.json'
@@ -4182,7 +4182,8 @@ def vzany_vzany_service_epg_check(index, total_checks, cversion, tversion, **kwa
 
                         if has_vzRtAnyToCons and has_vzRtAnyToProv:
                             result = MANUAL
-                            data.append(["CSCwk228974", "Service Graph with vzAny-vzAny, pcTag allocation change in Target Version"])
+                            data.append(["CSCwh75475", "Service Graph with vzAny-vzAny, pcTag allocation change in Target Version"])
+                            break
 
     print_result(title, result, msg, headers, data, recommended_action=recommended_action, doc_url=doc_url)
     return result

--- a/tests/vzany_vzany_service_epg_check/test_vzany_vzany_service_epg_check.py
+++ b/tests/vzany_vzany_service_epg_check/test_vzany_vzany_service_epg_check.py
@@ -1,0 +1,130 @@
+import os
+import pytest
+import logging
+import importlib
+from helpers.utils import read_data
+
+script = importlib.import_module("aci-preupgrade-validation-script")
+
+log = logging.getLogger(__name__)
+dir = os.path.dirname(os.path.abspath(__file__))
+
+
+# icurl queries
+vzRsSubjGraphAtts = "vzRsSubjGraphAtt.json"
+vzRtAnys = "uni/tn-T1/brc-contract1.json"
+vzRtAnys += "?query-target=children"
+vzRtAnys += "&target-subtree-class=vzRtAnyToCons,vzRtAnyToProv"
+
+
+@pytest.mark.parametrize(
+    "icurl_outputs, cversion, tversion, expected_result",
+    [
+        # Target version missing
+        (
+            {
+                vzRsSubjGraphAtts: read_data(dir, "vzRsSubjGraphAtt.json"),
+                vzRtAnys: read_data(dir, "vzRtAny_vzAny_vzAny.json"),
+            },
+            "3.2(10e)",
+            None,
+            script.MANUAL,
+        ),
+        # Version not affected
+        (
+            {
+                vzRsSubjGraphAtts: read_data(dir, "vzRsSubjGraphAtt.json"),
+                vzRtAnys: read_data(dir, "vzRtAny_vzAny_vzAny.json"),
+            },
+            "3.2(10e)",
+            "4.2(7f)",
+            script.NA,
+        ),
+        # Version not affected
+        (
+            {
+                vzRsSubjGraphAtts: read_data(dir, "vzRsSubjGraphAtt.json"),
+                vzRtAnys: read_data(dir, "vzRtAny_vzAny_vzAny.json"),
+            },
+            "5.0(1e)",
+            "5.2(8f)",
+            script.NA,
+        ),
+        # vzAny-vzAny in one VRF
+        (
+            {
+                vzRsSubjGraphAtts: read_data(dir, "vzRsSubjGraphAtt.json"),
+                vzRtAnys: read_data(dir, "vzRtAny_vzAny_vzAny.json"),
+            },
+            "4.2(7s)",
+            "5.2(8f)",
+            script.FAIL_O,
+        ),
+        # vzAny-vzAny in two VRFs
+        # vzAny as a provider is not supported for inter-VRF. The assumption is
+        # the same contract with scope VRF is used for two different VRFs as
+        # vzAny-vzAny on both VRFs individually.
+        (
+            {
+                vzRsSubjGraphAtts: read_data(dir, "vzRsSubjGraphAtt.json"),
+                vzRtAnys: read_data(dir, "vzRtAny_vzAny_vzAny_2_VRFs.json"),
+            },
+            "4.2(7s)",
+            "5.2(8f)",
+            script.FAIL_O,
+        ),
+        # vzAny prov only
+        (
+            {
+                vzRsSubjGraphAtts: read_data(dir, "vzRsSubjGraphAtt.json"),
+                vzRtAnys: read_data(dir, "vzRtAny_vzAny_prov_only.json"),
+            },
+            "4.2(7s)",
+            "5.2(8f)",
+            script.PASS,
+        ),
+        # vzAny prov in VRF A, vzAny cons in VRF B but not inter-VRF.
+        # vzAny as a provider is not supported for inter-VRF. The assumption is
+        # the same contract with scope VRF is used for two different VRFs as
+        # vzAny prov only in VRF A and vzAny cons only in VRF B.
+        # We do not consider a case where this is configured with a contract of
+        # scope tenant/global as that's not a supported configuration.
+        (
+            {
+                vzRsSubjGraphAtts: read_data(dir, "vzRsSubjGraphAtt.json"),
+                vzRtAnys: read_data(dir, "vzRtAny_vzAny_prov_cons_diff_VRFs.json"),
+            },
+            "4.2(7s)",
+            "5.2(8f)",
+            script.PASS,
+        ),
+        # no vzAny
+        (
+            {
+                vzRsSubjGraphAtts: read_data(dir, "vzRsSubjGraphAtt.json"),
+                vzRtAnys: [],
+            },
+            "4.2(7s)",
+            "5.2(8f)",
+            script.PASS,
+        ),
+        # no SG
+        (
+            {
+                vzRsSubjGraphAtts: [],
+                vzRtAnys: [],
+            },
+            "4.2(7s)",
+            "5.2(8f)",
+            script.PASS,
+        ),
+    ],
+)
+def test_logic(mock_icurl, cversion, tversion, expected_result):
+    result = script.vzany_vzany_service_epg_check(
+        1,
+        1,
+        script.AciVersion(cversion),
+        script.AciVersion(tversion) if tversion else None,
+    )
+    assert result == expected_result

--- a/tests/vzany_vzany_service_epg_check/vzRsSubjGraphAtt.json
+++ b/tests/vzany_vzany_service_epg_check/vzRsSubjGraphAtt.json
@@ -1,0 +1,15 @@
+[
+  {
+    "vzRsSubjGraphAtt": {
+      "attributes": {
+        "dn": "uni/tn-T1/brc-contract1/subj-S1/rsSubjGraphAtt",
+        "tCl": "vnsAbsGraph",
+        "tContextDn": "",
+        "tDn": "uni/tn-T1/AbsGraph-FW_PBR",
+        "tRn": "AbsGraph-FW_PBR",
+        "tType": "name",
+        "tnVnsAbsGraphName": "FW_PBR"
+      }
+    }
+  }
+]

--- a/tests/vzany_vzany_service_epg_check/vzRtAny_vzAny_prov_cons_diff_VRFs.json
+++ b/tests/vzany_vzany_service_epg_check/vzRtAny_vzAny_prov_cons_diff_VRFs.json
@@ -1,0 +1,21 @@
+[
+  {
+    "vzRtAnyToProv": {
+      "attributes": {
+        "dn": "uni/tn-T1/brc-contract1/rtanyToProv-[uni/tn-T1/ctx-VRFA/any]",
+        "tCl": "vzAny",
+        "tDn": "uni/tn-T1/ctx-VRFA/any"
+      }
+    }
+  },
+  {
+    "vzRtAnyToCons": {
+      "attributes": {
+        "dn": "uni/tn-T1/brc-contract1/rtanyToCons-[uni/tn-T1/ctx-VRFB/any]",
+        "tCl": "vzAny",
+        "tDn": "uni/tn-T1/ctx-VRFB/any"
+      }
+    }
+  }
+]
+

--- a/tests/vzany_vzany_service_epg_check/vzRtAny_vzAny_prov_only.json
+++ b/tests/vzany_vzany_service_epg_check/vzRtAny_vzAny_prov_only.json
@@ -1,0 +1,11 @@
+[
+  {
+    "vzRtAnyToProv": {
+      "attributes": {
+        "dn": "uni/tn-T1/brc-contract1/rtanyToProv-[uni/tn-T1/ctx-VRFA/any]",
+        "tCl": "vzAny",
+        "tDn": "uni/tn-T1/ctx-VRFA/any"
+      }
+    }
+  }
+]

--- a/tests/vzany_vzany_service_epg_check/vzRtAny_vzAny_vzAny.json
+++ b/tests/vzany_vzany_service_epg_check/vzRtAny_vzAny_vzAny.json
@@ -1,0 +1,30 @@
+[
+  {
+    "vzRtAnyToProv": {
+      "attributes": {
+        "dn": "uni/tn-T1/brc-contract1/rtanyToProv-[uni/tn-T1/ctx-VRFA/any]",
+        "tCl": "vzAny",
+        "tDn": "uni/tn-T1/ctx-VRFA/any"
+      }
+    }
+  },
+  {
+    "vzRtAnyToProv": {
+      "attributes": {
+        "dn": "uni/tn-T1/brc-contract1/rtanyToProv-[uni/tn-T1/ctx-VRFB/any]",
+        "tCl": "vzAny",
+        "tDn": "uni/tn-T1/ctx-VRFB/any"
+      }
+    }
+  },
+  {
+    "vzRtAnyToCons": {
+      "attributes": {
+        "dn": "uni/tn-T1/brc-contract1/rtanyToCons-[uni/tn-T1/ctx-VRFA/any]",
+        "tCl": "vzAny",
+        "tDn": "uni/tn-T1/ctx-VRFA/any"
+      }
+    }
+  }
+]
+

--- a/tests/vzany_vzany_service_epg_check/vzRtAny_vzAny_vzAny_2_VRFs.json
+++ b/tests/vzany_vzany_service_epg_check/vzRtAny_vzAny_vzAny_2_VRFs.json
@@ -1,0 +1,39 @@
+[
+  {
+    "vzRtAnyToProv": {
+      "attributes": {
+        "dn": "uni/tn-T1/brc-contract1/rtanyToProv-[uni/tn-T1/ctx-VRFA/any]",
+        "tCl": "vzAny",
+        "tDn": "uni/tn-T1/ctx-VRFA/any"
+      }
+    }
+  },
+  {
+    "vzRtAnyToProv": {
+      "attributes": {
+        "dn": "uni/tn-T1/brc-contract1/rtanyToProv-[uni/tn-T1/ctx-VRFB/any]",
+        "tCl": "vzAny",
+        "tDn": "uni/tn-T1/ctx-VRFB/any"
+      }
+    }
+  },
+  {
+    "vzRtAnyToCons": {
+      "attributes": {
+        "dn": "uni/tn-T1/brc-contract1/rtanyToCons-[uni/tn-T1/ctx-VRFA/any]",
+        "tCl": "vzAny",
+        "tDn": "uni/tn-T1/ctx-VRFA/any"
+      }
+    }
+  },
+  {
+    "vzRtAnyToCons": {
+      "attributes": {
+        "dn": "uni/tn-T1/brc-contract1/rtanyToCons-[uni/tn-T1/ctx-VRFA/any]",
+        "tCl": "vzAny",
+        "tDn": "uni/tn-T1/ctx-VRFB/any"
+      }
+    }
+  }
+]
+


### PR DESCRIPTION
APIC Preupgrade Validation Script to alert the administrator regarding the pcTag allocation change, when ACI fabric is upgraded from 4.x or earlier releases to 5.x or later releases.