### PR TITLE
`validate_32_64_bit_image_check`: na_image logic + pytest for 3 scenarios

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -4231,7 +4231,7 @@ def validate_32_64_bit_image_check(index, total_checks, cversion, tversion, **kw
     title = '32 and 64-Bit Firmware Image for Switches'
     result = PASS
     msg = ''
-    headers = ["Target Switch Version", "32-Bit Image Found", "64-Bit Image Found"]
+    headers = ["Target Switch Version", "32-Bit Image Found", "64-Bit Image Found", "NA Image(s) Found"]
     data = []
     recommended_action = 'Upload the missing 32 or 64 bit Switch Image to the Firmware repository'
     doc_url = 'https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#602-requires-32-and-64-bit-switch-images'
@@ -4246,7 +4246,7 @@ def validate_32_64_bit_image_check(index, total_checks, cversion, tversion, **kw
         return POST
 
     if cversion.newer_than("6.0(2a)") and tversion.newer_than("6.0(2a)"):
-        found32 = found64 = False
+        found32 = found64 = na_image = False
         target_sw_ver = 'n9000-1' + tversion.version
         firmware_api =	'firmwareFirmware.json'
         firmware_api +=	'?query-target-filter=eq(firmwareFirmware.fullVersion,"%s")' % (target_sw_ver)  
@@ -4257,10 +4257,13 @@ def validate_32_64_bit_image_check(index, total_checks, cversion, tversion, **kw
                 found32 = True
             elif firmware['firmwareFirmware']['attributes']['bitInfo'] == '64':
                 found64 = True
+            elif firmware['firmwareFirmware']['attributes']['bitInfo'] == 'NA':
+                na_image = True
+                recommended_action += '\n     NA bitinfo on switch image found, remove and reupload to APIC fwrepo'
 
         if not found32 or not found64:
             result = FAIL_UF
-            data.append([target_sw_ver, found32, found64])
+            data.append([target_sw_ver, found32, found64, na_image])
 
     else:
         result = NA

--- a/tests/validate_32_64_bit_image_check/firmwareFirmware_pos2.json
+++ b/tests/validate_32_64_bit_image_check/firmwareFirmware_pos2.json
@@ -1,0 +1,78 @@
+[
+    {
+      "firmwareFirmware": {
+        "attributes": {
+          "annotation": "",
+          "autoloadCatalog": "no",
+          "bitInfo": "NA",
+          "checksum": "26e61c295b00703002d69eda76526e3d",
+          "childAction": "",
+          "deleteIt": "no",
+          "description": "",
+          "dn": "fwrepo/fw-aci-n9000-system.16.0.3e-cs_64.bin",
+          "dnldStatus": "downloaded",
+          "downloadDate": "2024-04-09T11:18:11.054-04:00",
+          "extMngdBy": "",
+          "fullVersion": "n9000-16.0(3e)",
+          "iUrl": "/var/run/mgmt/fwrepos/fwrepo/aci-n9000-dk9.16.0.3e-cs_64.bin",
+          "isoname": "aci-n9000-dk9.16.0.3e-cs_64.bin",
+          "latest": "no",
+          "lcOwn": "local",
+          "minorVersion": "(3e)",
+          "modTs": "2024-04-11T15:53:39.984-04:00",
+          "name": "aci-n9000-system.16.0.3e-cs_64.bin",
+          "origFileName": "",
+          "releaseDate": "2023-08-18T01:41:46.000-04:00",
+          "restartType": "NA",
+          "rn": "fw-aci-n9000-system.16.0.3e-cs_64.bin",
+          "size": "2593945834",
+          "size64": "2593945834",
+          "status": "",
+          "syncComplete": "111",
+          "type": "switch",
+          "uid": "0",
+          "url": "/fwrepo/aci-n9000-dk9.16.0.3e-cs_64.bin",
+          "userdom": "all",
+          "version": "16.0"
+        }
+      }
+    },
+    {
+      "firmwareFirmware": {
+        "attributes": {
+          "annotation": "",
+          "autoloadCatalog": "no",
+          "bitInfo": "NA",
+          "checksum": "fe7d6492a4d05e57910742f8f0d0252c",
+          "childAction": "",
+          "deleteIt": "no",
+          "description": "",
+          "dn": "fwrepo/fw-aci-n9000-system.16.0.3e.bin",
+          "dnldStatus": "downloaded",
+          "downloadDate": "2024-04-09T11:14:28.846-04:00",
+          "extMngdBy": "",
+          "fullVersion": "n9000-16.0(3e)",
+          "iUrl": "/var/run/mgmt/fwrepos/fwrepo/aci-n9000-dk9.16.0.3e.bin",
+          "isoname": "aci-n9000-dk9.16.0.3e.bin",
+          "latest": "no",
+          "lcOwn": "local",
+          "minorVersion": "(3e)",
+          "modTs": "2024-04-11T15:53:39.984-04:00",
+          "name": "aci-n9000-system.16.0.3e.bin",
+          "origFileName": "",
+          "releaseDate": "2023-08-18T01:48:25.000-04:00",
+          "restartType": "NA",
+          "rn": "fw-aci-n9000-system.16.0.3e.bin",
+          "size": "2418748405",
+          "size64": "2418748405",
+          "status": "",
+          "syncComplete": "111",
+          "type": "switch",
+          "uid": "0",
+          "url": "/fwrepo/aci-n9000-dk9.16.0.3e.bin",
+          "userdom": "all",
+          "version": "16.0"
+        }
+      }
+    }
+  ]

--- a/tests/validate_32_64_bit_image_check/firmwareFirmware_pos3.json
+++ b/tests/validate_32_64_bit_image_check/firmwareFirmware_pos3.json
@@ -1,0 +1,78 @@
+[
+    {
+      "firmwareFirmware": {
+        "attributes": {
+          "annotation": "",
+          "autoloadCatalog": "no",
+          "bitInfo": "64",
+          "checksum": "26e61c295b00703002d69eda76526e3d",
+          "childAction": "",
+          "deleteIt": "no",
+          "description": "",
+          "dn": "fwrepo/fw-aci-n9000-system.16.0.3e-cs_64.bin",
+          "dnldStatus": "downloaded",
+          "downloadDate": "2024-04-09T11:18:11.054-04:00",
+          "extMngdBy": "",
+          "fullVersion": "n9000-16.0(3e)",
+          "iUrl": "/var/run/mgmt/fwrepos/fwrepo/aci-n9000-dk9.16.0.3e-cs_64.bin",
+          "isoname": "aci-n9000-dk9.16.0.3e-cs_64.bin",
+          "latest": "no",
+          "lcOwn": "local",
+          "minorVersion": "(3e)",
+          "modTs": "2024-04-11T15:53:39.984-04:00",
+          "name": "aci-n9000-system.16.0.3e-cs_64.bin",
+          "origFileName": "",
+          "releaseDate": "2023-08-18T01:41:46.000-04:00",
+          "restartType": "NA",
+          "rn": "fw-aci-n9000-system.16.0.3e-cs_64.bin",
+          "size": "2593945834",
+          "size64": "2593945834",
+          "status": "",
+          "syncComplete": "111",
+          "type": "switch",
+          "uid": "0",
+          "url": "/fwrepo/aci-n9000-dk9.16.0.3e-cs_64.bin",
+          "userdom": "all",
+          "version": "16.0"
+        }
+      }
+    },
+    {
+      "firmwareFirmware": {
+        "attributes": {
+          "annotation": "",
+          "autoloadCatalog": "no",
+          "bitInfo": "NA",
+          "checksum": "fe7d6492a4d05e57910742f8f0d0252c",
+          "childAction": "",
+          "deleteIt": "no",
+          "description": "",
+          "dn": "fwrepo/fw-aci-n9000-system.16.0.3e.bin",
+          "dnldStatus": "downloaded",
+          "downloadDate": "2024-04-09T11:14:28.846-04:00",
+          "extMngdBy": "",
+          "fullVersion": "n9000-16.0(3e)",
+          "iUrl": "/var/run/mgmt/fwrepos/fwrepo/aci-n9000-dk9.16.0.3e.bin",
+          "isoname": "aci-n9000-dk9.16.0.3e.bin",
+          "latest": "no",
+          "lcOwn": "local",
+          "minorVersion": "(3e)",
+          "modTs": "2024-04-11T15:53:39.984-04:00",
+          "name": "aci-n9000-system.16.0.3e.bin",
+          "origFileName": "",
+          "releaseDate": "2023-08-18T01:48:25.000-04:00",
+          "restartType": "NA",
+          "rn": "fw-aci-n9000-system.16.0.3e.bin",
+          "size": "2418748405",
+          "size64": "2418748405",
+          "status": "",
+          "syncComplete": "111",
+          "type": "switch",
+          "uid": "0",
+          "url": "/fwrepo/aci-n9000-dk9.16.0.3e.bin",
+          "userdom": "all",
+          "version": "16.0"
+        }
+      }
+    }
+  ]

--- a/tests/validate_32_64_bit_image_check/firmwareFirmware_pos4.json
+++ b/tests/validate_32_64_bit_image_check/firmwareFirmware_pos4.json
@@ -1,0 +1,78 @@
+[
+    {
+      "firmwareFirmware": {
+        "attributes": {
+          "annotation": "",
+          "autoloadCatalog": "no",
+          "bitInfo": "NA",
+          "checksum": "26e61c295b00703002d69eda76526e3d",
+          "childAction": "",
+          "deleteIt": "no",
+          "description": "",
+          "dn": "fwrepo/fw-aci-n9000-system.16.0.3e-cs_64.bin",
+          "dnldStatus": "downloaded",
+          "downloadDate": "2024-04-09T11:18:11.054-04:00",
+          "extMngdBy": "",
+          "fullVersion": "n9000-16.0(3e)",
+          "iUrl": "/var/run/mgmt/fwrepos/fwrepo/aci-n9000-dk9.16.0.3e-cs_64.bin",
+          "isoname": "aci-n9000-dk9.16.0.3e-cs_64.bin",
+          "latest": "no",
+          "lcOwn": "local",
+          "minorVersion": "(3e)",
+          "modTs": "2024-04-11T15:53:39.984-04:00",
+          "name": "aci-n9000-system.16.0.3e-cs_64.bin",
+          "origFileName": "",
+          "releaseDate": "2023-08-18T01:41:46.000-04:00",
+          "restartType": "NA",
+          "rn": "fw-aci-n9000-system.16.0.3e-cs_64.bin",
+          "size": "2593945834",
+          "size64": "2593945834",
+          "status": "",
+          "syncComplete": "111",
+          "type": "switch",
+          "uid": "0",
+          "url": "/fwrepo/aci-n9000-dk9.16.0.3e-cs_64.bin",
+          "userdom": "all",
+          "version": "16.0"
+        }
+      }
+    },
+    {
+      "firmwareFirmware": {
+        "attributes": {
+          "annotation": "",
+          "autoloadCatalog": "no",
+          "bitInfo": "32",
+          "checksum": "fe7d6492a4d05e57910742f8f0d0252c",
+          "childAction": "",
+          "deleteIt": "no",
+          "description": "",
+          "dn": "fwrepo/fw-aci-n9000-system.16.0.3e.bin",
+          "dnldStatus": "downloaded",
+          "downloadDate": "2024-04-09T11:14:28.846-04:00",
+          "extMngdBy": "",
+          "fullVersion": "n9000-16.0(3e)",
+          "iUrl": "/var/run/mgmt/fwrepos/fwrepo/aci-n9000-dk9.16.0.3e.bin",
+          "isoname": "aci-n9000-dk9.16.0.3e.bin",
+          "latest": "no",
+          "lcOwn": "local",
+          "minorVersion": "(3e)",
+          "modTs": "2024-04-11T15:53:39.984-04:00",
+          "name": "aci-n9000-system.16.0.3e.bin",
+          "origFileName": "",
+          "releaseDate": "2023-08-18T01:48:25.000-04:00",
+          "restartType": "NA",
+          "rn": "fw-aci-n9000-system.16.0.3e.bin",
+          "size": "2418748405",
+          "size64": "2418748405",
+          "status": "",
+          "syncComplete": "111",
+          "type": "switch",
+          "uid": "0",
+          "url": "/fwrepo/aci-n9000-dk9.16.0.3e.bin",
+          "userdom": "all",
+          "version": "16.0"
+        }
+      }
+    }
+  ]

--- a/tests/validate_32_64_bit_image_check/test_validate_32_64_bit_image_check.py
+++ b/tests/validate_32_64_bit_image_check/test_validate_32_64_bit_image_check.py
@@ -44,6 +44,30 @@ firmware_52_api +=	'?query-target-filter=eq(firmwareFirmware.fullVersion,"n9000-
             "6.0(3e)",
             script.FAIL_UF,
         ),
+        ## FAILING = AFFECTED VERSION + Images were uploaded before upgrade
+        (
+            {firmware_60_api: read_data(dir, "firmwareFirmware_pos2.json"), 
+            },
+            "6.0(3e)",
+            "6.0(3e)",
+            script.FAIL_UF,
+        ),
+        ## FAILING = AFFECTED VERSION + 32-bit image shows NA
+        (
+            {firmware_60_api: read_data(dir, "firmwareFirmware_pos3.json"), 
+            },
+            "6.0(3e)",
+            "6.0(3e)",
+            script.FAIL_UF,
+        ),
+        ## FAILING = AFFECTED VERSION + 64-bit image shows NA
+        (
+            {firmware_60_api: read_data(dir, "firmwareFirmware_pos4.json"), 
+            },
+            "6.0(3e)",
+            "6.0(3e)",
+            script.FAIL_UF,
+        ),
         ## FAILING = AFFECTED VERSION + AFFECTED MO NON EXISTING
         (
             {firmware_60_api: read_data(dir, "firmwareFirmware_empty.json"),


### PR DESCRIPTION
updated pytest output:
```
[Check  1/1] 32 and 64-Bit Firmware Image for Switches... Target version not supplied. Skipping.                    MANUAL CHECK REQUIRED
[Check  1/1] 32 and 64-Bit Firmware Image for Switches... Re-run after APICs are upgraded to 6.0(2) or later  POST UPGRADE CHECK REQUIRED
[Check  1/1] 32 and 64-Bit Firmware Image for Switches...                                                        FAIL - UPGRADE FAILURE!!
  Target Switch Version  32-Bit Image Found  64-Bit Image Found  NA Image Found
  ---------------------  ------------------  ------------------  --------------
  n9000-16.0(3e)         False               True                False

  Recommended Action: Upload the missing 32 or 64 bit Switch Image to the Firmware repository
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#602-requires-32-and-64-bit-switch-images


[Check  1/1] 32 and 64-Bit Firmware Image for Switches...                                                        FAIL - UPGRADE FAILURE!!
  Target Switch Version  32-Bit Image Found  64-Bit Image Found  NA Image Found
  ---------------------  ------------------  ------------------  --------------
  n9000-16.0(3e)         False               False               True

  Recommended Action: Upload the missing 32 or 64 bit Switch Image to the Firmware repository
     NA bitinfo on switch image found, remove and reupload to APIC fwrepo
     NA bitinfo on switch image found, remove and reupload to APIC fwrepo
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#602-requires-32-and-64-bit-switch-images


[Check  1/1] 32 and 64-Bit Firmware Image for Switches...                                                        FAIL - UPGRADE FAILURE!!
  Target Switch Version  32-Bit Image Found  64-Bit Image Found  NA Image Found
  ---------------------  ------------------  ------------------  --------------
  n9000-16.0(3e)         False               True                True

  Recommended Action: Upload the missing 32 or 64 bit Switch Image to the Firmware repository
     NA bitinfo on switch image found, remove and reupload to APIC fwrepo
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#602-requires-32-and-64-bit-switch-images


[Check  1/1] 32 and 64-Bit Firmware Image for Switches...                                                        FAIL - UPGRADE FAILURE!!
  Target Switch Version  32-Bit Image Found  64-Bit Image Found  NA Image Found
  ---------------------  ------------------  ------------------  --------------
  n9000-16.0(3e)         True                False               True

  Recommended Action: Upload the missing 32 or 64 bit Switch Image to the Firmware repository
     NA bitinfo on switch image found, remove and reupload to APIC fwrepo
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#602-requires-32-and-64-bit-switch-images


[Check  1/1] 32 and 64-Bit Firmware Image for Switches...                                                        FAIL - UPGRADE FAILURE!!
  Target Switch Version  32-Bit Image Found  64-Bit Image Found  NA Image Found
  ---------------------  ------------------  ------------------  --------------
  n9000-16.0(3e)         False               False               False

  Recommended Action: Upload the missing 32 or 64 bit Switch Image to the Firmware repository
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#602-requires-32-and-64-bit-switch-images


[Check  1/1] 32 and 64-Bit Firmware Image for Switches...                                                                            PASS
[Check  1/1] 32 and 64-Bit Firmware Image for Switches... Target version below 6.0(2)                                                 N/A
