### PR TITLE
Add HTTPS Request Throttle Rate check

### DIFF
--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -121,7 +121,8 @@ Items                                         | Faults         | This Script    
 [Unsupported FEC Configuration for N9K-C93180YC-EX][c16]    | :white_check_mark: | :no_entry_sign:           | :no_entry_sign:
 [CloudSec Encryption Check][c17]                      | :white_check_mark: | :no_entry_sign:           | :no_entry_sign:
 [Out-of-Service Ports check][c18]                     | :white_check_mark: | :no_entry_sign:           | :no_entry_sign:  
-[TEP-to-TEP atomic counters Scalability Check][c19]    | :white_check_mark: | :no_entry_sign:           | :no_entry_sign:
+[TEP-to-TEP atomic counters Scalability Check][c19]   | :white_check_mark: | :no_entry_sign:           | :no_entry_sign:
+[HTTPS Request Throttle Rate][c20]                    | :white_check_mark: | :no_entry_sign:           | :no_entry_sign:
 
 [c1]: #vpc-paired-leaf-switches
 [c2]: #overlapping-vlan-pool
@@ -142,6 +143,7 @@ Items                                         | Faults         | This Script    
 [c17]: #cloudsec-encryption-check
 [c18]: #out-of-service-ports-check
 [c19]: #tep-to-tep-atomic-counters-scalability-check
+[c20]: #https-request-throttle-rate
 
 ### Defect Condition Checks
 
@@ -1987,6 +1989,24 @@ Exceeding any scalability number documented in this guide can cause unexpected i
 The script validates the count of `dbgAcPath` is less than the documented supported number. 
 
 
+### HTTPS Request Throttle Rate
+
+ACI supports **HTTPS Request Throttle** via NGINX rate limit to prevent external API clients from consuming too much resources on APICs. This feature, which is disabled by default, is located at `Fabric > Fabric Policies > Pod > Management Access > default (or name you configured)` in the APIC GUI.
+
+Starting from ACI version 6.1(2), the supported maximum rate for this feature was reduced to 40 requests per second (r/s) or 2400 requests per minute (r/m) from 10,000 r/m. Configuration with a value larger than these gets rejected starting from 6.1(2).
+This change is to ensure that users using this feature configure a meaningful rate. If the rate is larger than the new maximum, APIC may not be able to keep up with incoming requests despite the throttling in place, and the APIC GUI can get sluggish or unresponsive which defeats the purpose of the feature.
+
+This script checks the configuration in all Management Access Policies to alert users when the following conditions are met because APIC upgrade will fail in such a case.
+
+* The upgrade is from a version older than 6.1(2a) to a version newer than 6.1(2a). (ex. 5.2(8g) to 6.1(2h))
+* HTTPS Request Throttling is enabled and its rate is larger than 40 r/s or 2400 r/m
+
+!!! tip
+    Regardless of the APIC version, the best practice is to enable **HTTPS Request Throttle** with 30 requests per second. See [ACI Best Practices Quick Summary][47] for reference and details about the feature.
+
+    Also note that **HTTPS Request Throttle** in this check is referring to the global throttling as opposed to the new feature **Custom Throttle Group** that was introduced in 6.1(2).
+
+
 ## Defect Check Details
 
 ### EP Announce Compatibility
@@ -2360,3 +2380,4 @@ This check will count the number of relevant PBR policies across the entire ACI 
 [44]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwd65255
 [45]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwk77800
 [46]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwi66348
+[47]: https://www.cisco.com/c/en/us/td/docs/dcn/whitepapers/cisco-aci-best-practices-quick-summary.html#HTTPSRequestThrottle

--- a/tests/https_throttle_rate_check/commHttps_neg1.json
+++ b/tests/https_throttle_rate_check/commHttps_neg1.json
@@ -1,0 +1,23 @@
+[
+  {
+    "commHttps": {
+      "attributes": {
+        "dn": "uni/fabric/comm-default/https",
+        "globalThrottleRate": "40",
+        "globalThrottleSt": "enabled",
+        "globalThrottleUnit": "r/s"
+      }
+    }
+  },
+  {
+    "commHttps": {
+      "attributes": {
+        "dn": "uni/fabric/comm-mgmt1/https",
+        "globalThrottleRate": "2400",
+        "globalThrottleSt": "enabled",
+        "globalThrottleUnit": "r/m"
+      }
+    }
+  }
+]
+

--- a/tests/https_throttle_rate_check/commHttps_neg2.json
+++ b/tests/https_throttle_rate_check/commHttps_neg2.json
@@ -1,0 +1,23 @@
+[
+  {
+    "commHttps": {
+      "attributes": {
+        "dn": "uni/fabric/comm-default/https",
+        "globalThrottleRate": "10000",
+        "globalThrottleSt": "disabled",
+        "globalThrottleUnit": "r/s"
+      }
+    }
+  },
+  {
+    "commHttps": {
+      "attributes": {
+        "dn": "uni/fabric/comm-mgmt1/https",
+        "globalThrottleRate": "10000",
+        "globalThrottleSt": "disabled",
+        "globalThrottleUnit": "r/m"
+      }
+    }
+  }
+]
+

--- a/tests/https_throttle_rate_check/commHttps_pos.json
+++ b/tests/https_throttle_rate_check/commHttps_pos.json
@@ -1,0 +1,33 @@
+[
+  {
+    "commHttps": {
+      "attributes": {
+        "dn": "uni/fabric/comm-default/https",
+        "globalThrottleRate": "10000",
+        "globalThrottleSt": "enabled",
+        "globalThrottleUnit": "r/s"
+      }
+    }
+  },
+  {
+    "commHttps": {
+      "attributes": {
+        "dn": "uni/fabric/comm-mgmt1/https",
+        "globalThrottleRate": "2401",
+        "globalThrottleSt": "enabled",
+        "globalThrottleUnit": "r/m"
+      }
+    }
+  },
+  {
+    "commHttps": {
+      "attributes": {
+        "dn": "uni/fabric/comm-mgmt2/https",
+        "globalThrottleRate": "41",
+        "globalThrottleSt": "enabled",
+        "globalThrottleUnit": "r/s"
+      }
+    }
+  }
+]
+

--- a/tests/https_throttle_rate_check/test_https_throttle_rate_check.py
+++ b/tests/https_throttle_rate_check/test_https_throttle_rate_check.py
@@ -1,0 +1,75 @@
+﻿import os
+import pytest
+import logging
+import importlib
+from helpers.utils import read_data
+
+script = importlib.import_module("aci-preupgrade-validation-script")
+
+log = logging.getLogger(__name__)
+dir = os.path.dirname(os.path.abspath(__file__))
+
+
+# icurl queries
+commHttps = "commHttps.json"
+
+
+@pytest.mark.parametrize(
+    "icurl_outputs, cver, tver, expected_result",
+    [
+        # Target version missing
+        (
+            {commHttps: read_data(dir, "commHttps_neg1.json")},
+            "4.2(7f)",
+            None,
+            script.MANUAL,
+        ),
+        # Version not affected. cversion newer than 6.1(2a). Upgrade
+        (
+            {commHttps: read_data(dir, "commHttps_neg1.json")},
+            "6.1(2g)",
+            "6.1(3a)",
+            script.NA,
+        ),
+        # Version not affected. cversion newer than 6.1(2a). Downgrade
+        (
+            {commHttps: read_data(dir, "commHttps_neg1.json")},
+            "6.1(2g)",
+            "5.2(8g)",
+            script.NA,
+        ),
+        # Version not affected. Both cversion and tversion older than 6.1(2).
+        (
+            {commHttps: read_data(dir, "commHttps_neg1.json")},
+            "4.2(7f)",
+            "5.2(8g)",
+            script.NA,
+        ),
+        # Throttle rates are lower than the threshold
+        (
+            {commHttps: read_data(dir, "commHttps_neg1.json")},
+            "4.2(7f)",
+            "6.1(2g)",
+            script.PASS,
+        ),
+        # Throttle rates are higher than the threshold but throttling is disabled.
+        (
+            {commHttps: read_data(dir, "commHttps_neg2.json")},
+            "4.2(7f)",
+            "6.1(2g)",
+            script.PASS,
+        ),
+        # Throttle rates are higher than the threshold but throttling is enabled.
+        (
+            {commHttps: read_data(dir, "commHttps_pos.json")},
+            "4.2(7f)",
+            "6.1(2g)",
+            script.FAIL_UF,
+        ),
+    ],
+)
+def test_logic(mock_icurl, cver, tver, expected_result):
+    cversion = script.AciVersion(cver)
+    tversion = script.AciVersion(tver) if tver else None
+    result = script.https_throttle_rate_check(1, 1, cversion, tversion)
+    assert result == expected_result


### PR DESCRIPTION
fix #197 

pytest result:
```
[Check  1/1] HTTPS Request Throttle Rate... Target version not supplied. Skipping.                                  MANUAL CHECK REQUIRED
[Check  1/1] HTTPS Request Throttle Rate...                                                                                           N/A
[Check  1/1] HTTPS Request Throttle Rate...                                                                                           N/A 
[Check  1/1] HTTPS Request Throttle Rate...                                                                                           N/A
[Check  1/1] HTTPS Request Throttle Rate...                                                                                          PASS
[Check  1/1] HTTPS Request Throttle Rate...                                                                                          PASS 
[Check  1/1] HTTPS Request Throttle Rate...                                                                      FAIL - UPGRADE FAILURE!!
  Mgmt Access Policy  HTTPS Throttle Rate
  ------------------  -------------------
  default             10000 (r/s)
  mgmt1               2401 (r/m)
  mgmt2               41 (r/s)

  Recommended Action: Reduce the throttle rate to 40 (req/sec), 2400 (req/min) or lower.
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#https-request-throttle-rate
```

integration tests also passed.