### PR TITLE
fix: Handle `l3extLoopBackIfP` with a subnet mask for L3Out Loopback Overlap check

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -2382,8 +2382,9 @@ def l3out_overlapping_loopback_check(index, total_checks, **kwargs):
                                     loopback_ip = lb['l3extLoopBackIfP']['attributes']['addr']
                                     break
                         if loopback_ip:
+                            lo_addr = loopback_ip.split("/")[0]  # l3extLoopBackIfP.addr can be with or without /32, /128.
                             loopback_ips[node_id] = {
-                                'addr': loopback_ip,
+                                'addr': lo_addr,
                                 'config': ':'.join([tenant_name, l3out_name, nodep_name]),
                             }
                     # Get interface IPs for each node

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -2346,7 +2346,7 @@ def l3out_overlapping_loopback_check(index, total_checks, **kwargs):
     l3outs = icurl('class', api)
     for l3out in l3outs:
         vrf = ""
-        loopback_ips = defaultdict(dict)
+        loopback_ips = defaultdict(list)
         interface_ips = defaultdict(list)
         for child in l3out['l3extOut'].get('children', []):
             dn = re.search(tn_regex, l3out['l3extOut']['attributes']['dn'])
@@ -2372,21 +2372,24 @@ def l3out_overlapping_loopback_check(index, total_checks, **kwargs):
                             continue
                         node_id = m.group('node')
 
-                        loopback_ip = ''
+                        config = ':'.join([tenant_name, l3out_name, nodep_name])
                         if node['attributes']['rtrIdLoopBack'] == 'yes':
-                            loopback_ip = node['attributes']['rtrId']
+                            loopback_ips[node_id].append({
+                                'addr': node['attributes']['rtrId'],
+                                'config': config,
+                            })
                         else:
                             for lb in node.get('children', []):
-                                # There should be only one l3extLoopBackIfP per node
-                                if lb.get('l3extLoopBackIfP'):
-                                    loopback_ip = lb['l3extLoopBackIfP']['attributes']['addr']
-                                    break
-                        if loopback_ip:
-                            lo_addr = loopback_ip.split("/")[0]  # l3extLoopBackIfP.addr can be with or without /32, /128.
-                            loopback_ips[node_id] = {
-                                'addr': lo_addr,
-                                'config': ':'.join([tenant_name, l3out_name, nodep_name]),
-                            }
+                                # One l3extLoopBackIfP per node for each IPv4/v6
+                                if not lb.get('l3extLoopBackIfP'):
+                                    continue
+                                loopback_ip = lb['l3extLoopBackIfP']['attributes']['addr']
+                                # Strip the subnet mask (/32, /128) if any
+                                lo_addr = loopback_ip.split("/")[0]
+                                loopback_ips[node_id].append({
+                                    'addr': lo_addr,
+                                    'config': config,
+                                })
                     # Get interface IPs for each node
                     elif np_child.get('l3extLIfP'):
                         ifp_name = np_child['l3extLIfP']['attributes']['name']
@@ -2422,7 +2425,7 @@ def l3out_overlapping_loopback_check(index, total_checks, **kwargs):
         for node in loopback_ips:
             if not vrfs[vrf].get(node):
                 vrfs[vrf][node] = {}
-            vrfs[vrf][node]['loopback'] = loopback_ips[node]
+            vrfs[vrf][node]['loopbacks'] = vrfs[vrf][node].get('loopbacks', []) + loopback_ips[node]
         for node in interface_ips:
             if not vrfs[vrf].get(node):
                 vrfs[vrf][node] = {}
@@ -2431,18 +2434,19 @@ def l3out_overlapping_loopback_check(index, total_checks, **kwargs):
     # Check overlaps
     for vrf in vrfs:
         for node in vrfs[vrf]:
-            loopback = vrfs[vrf][node].get('loopback')
+            loopbacks = vrfs[vrf][node].get('loopbacks')
             interfaces = vrfs[vrf][node].get('interfaces')
-            if not loopback or not interfaces:
+            if not loopbacks or not interfaces:
                 continue
             for interface in interfaces:
-                if IPAddress.ip_in_subnet(loopback['addr'], interface['addr']):
-                    data.append([
-                        vrf,
-                        node,
-                        '{} ({})'.format(loopback['addr'], loopback['config']),
-                        '{} ({})'.format(interface['addr'], interface['config']),
-                    ])
+                for loopback in loopbacks:
+                    if IPAddress.ip_in_subnet(loopback['addr'], interface['addr']):
+                        data.append([
+                            vrf,
+                            node,
+                            '{} ({})'.format(loopback['addr'], loopback['config']),
+                            '{} ({})'.format(interface['addr'], interface['config']),
+                        ])
     if not data:
         result = PASS
     print_result(title, result, msg, headers, data, recommended_action=recommended_action, doc_url=doc_url)

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -412,6 +412,10 @@ class IPAddress:
 
     @classmethod
     def ip_in_subnet(cls, ip, subnet):
+        if "/" in ip:
+            raise ValueError(
+                "IP address {} should not have a subnet mask".format(ip)
+            )
         if "/" not in subnet:
             return False
         subnet_ip, subnet_pfxlen = subnet.split("/")

--- a/tests/l3out_overlapping_loopback_check/same_l3out_loopback_with_subnet_mask.json
+++ b/tests/l3out_overlapping_loopback_check/same_l3out_loopback_with_subnet_mask.json
@@ -465,102 +465,36 @@
         {
           "l3extLNodeP": {
             "attributes": {
-              "annotation": "orchestrator:terraform",
-              "childAction": "",
-              "configIssues": "",
-              "descr": "",
-              "extMngdBy": "",
-              "lcOwn": "local",
-              "modTs": "2024-04-12T09:55:55.488-07:00",
-              "monPolDn": "uni/tn-common/monepg-default",
-              "name": "IPv4",
-              "nameAlias": "",
-              "ownerKey": "",
-              "ownerTag": "",
-              "rn": "lnodep-IPv4",
-              "status": "",
-              "tag": "yellow-green",
-              "targetDscp": "unspecified",
-              "uid": "15374"
+              "name": "IPv4"
             },
             "children": [
               {
                 "l3extLIfP": {
                   "attributes": {
-                    "addr": "0.0.0.0",
-                    "annotation": "orchestrator:terraform",
-                    "childAction": "",
-                    "descr": "",
-                    "encap": "unknown",
-                    "extMngdBy": "",
-                    "lcOwn": "local",
-                    "modTs": "2024-04-12T09:56:01.299-07:00",
-                    "monPolDn": "uni/tn-common/monepg-default",
-                    "name": "IFP",
-                    "nameAlias": "",
-                    "ownerKey": "",
-                    "ownerTag": "",
-                    "prio": "unspecified",
-                    "rn": "lifp-IFP",
-                    "status": "",
-                    "tag": "yellow-green",
-                    "targetDscp": "unspecified",
-                    "uid": "15374"
+                    "name": "IFP"
                   },
                   "children": [
                     {
                       "l3extRsPathL3OutAtt": {
                         "attributes": {
                           "addr": "0.0.0.0",
-                          "annotation": "orchestrator:terraform",
-                          "autostate": "disabled",
-                          "childAction": "",
-                          "configIssues": "",
-                          "descr": "",
                           "encap": "vlan-1051",
                           "encapScope": "local",
-                          "extMngdBy": "",
-                          "forceResolve": "yes",
                           "ifInstT": "ext-svi",
                           "ipv6Dad": "enabled",
-                          "lcOwn": "local",
                           "llAddr": "::",
-                          "mac": "00:22:BD:F8:19:FF",
-                          "modTs": "2024-04-12T09:56:03.804-07:00",
                           "mode": "regular",
-                          "monPolDn": "uni/tn-common/monepg-default",
-                          "mtu": "9000",
-                          "rType": "mo",
-                          "rn": "rspathL3OutAtt-[topology/pod-1/protpaths-103-104/pathep-[N9K_VPC_3-4_13]]",
-                          "state": "unformed",
-                          "stateQual": "none",
-                          "status": "",
                           "tCl": "fabricPathEp",
-                          "tDn": "topology/pod-1/protpaths-103-104/pathep-[N9K_VPC_3-4_13]",
-                          "tType": "mo",
-                          "targetDscp": "unspecified",
-                          "uid": "15374"
+                          "tDn": "topology/pod-1/protpaths-103-104/pathep-[N9K_VPC_3-4_13]"
                         },
                         "children": [
                           {
                             "l3extMember": {
                               "attributes": {
                                 "addr": "10.0.0.40/25",
-                                "annotation": "orchestrator:terraform",
-                                "childAction": "",
-                                "descr": "",
-                                "extMngdBy": "",
                                 "ipv6Dad": "enabled",
-                                "lcOwn": "local",
                                 "llAddr": "::",
-                                "modTs": "2024-05-08T13:12:40.876-07:00",
-                                "monPolDn": "uni/tn-common/monepg-default",
-                                "name": "",
-                                "nameAlias": "",
-                                "rn": "mem-B",
-                                "side": "B",
-                                "status": "",
-                                "uid": "15374"
+                                "side": "B"
                               }
                             }
                           },
@@ -568,21 +502,9 @@
                             "l3extMember": {
                               "attributes": {
                                 "addr": "10.0.0.30/25",
-                                "annotation": "orchestrator:terraform",
-                                "childAction": "",
-                                "descr": "",
-                                "extMngdBy": "",
                                 "ipv6Dad": "enabled",
-                                "lcOwn": "local",
                                 "llAddr": "::",
-                                "modTs": "2024-05-08T13:12:40.876-07:00",
-                                "monPolDn": "uni/tn-common/monepg-default",
-                                "name": "",
-                                "nameAlias": "",
-                                "rn": "mem-A",
-                                "side": "A",
-                                "status": "",
-                                "uid": "15374"
+                                "side": "A"
                               }
                             }
                           }
@@ -595,43 +517,16 @@
               {
                 "l3extRsNodeL3OutAtt": {
                   "attributes": {
-                    "annotation": "orchestrator:terraform",
-                    "childAction": "",
-                    "configIssues": "",
-                    "extMngdBy": "",
-                    "forceResolve": "yes",
-                    "lcOwn": "local",
-                    "modTs": "2024-05-08T16:44:55.748-07:00",
-                    "monPolDn": "uni/tn-common/monepg-default",
-                    "rType": "mo",
-                    "rn": "rsnodeL3OutAtt-[topology/pod-1/node-104]",
                     "rtrId": "10.0.0.4",
                     "rtrIdLoopBack": "no",
-                    "state": "unformed",
-                    "stateQual": "none",
-                    "status": "",
                     "tCl": "fabricNode",
-                    "tDn": "topology/pod-1/node-104",
-                    "tType": "mo",
-                    "uid": "15374"
+                    "tDn": "topology/pod-1/node-104"
                   },
                   "children": [
                     {
                       "l3extLoopBackIfP": {
                         "attributes": {
-                          "addr": "10.0.0.104",
-                          "annotation": "",
-                          "childAction": "",
-                          "descr": "",
-                          "extMngdBy": "",
-                          "lcOwn": "local",
-                          "modTs": "2024-05-08T16:44:52.670-07:00",
-                          "monPolDn": "uni/tn-common/monepg-default",
-                          "name": "",
-                          "nameAlias": "",
-                          "rn": "lbp-[10.0.0.104]",
-                          "status": "",
-                          "uid": "15374"
+                          "addr": "10.0.0.104/32"
                         }
                       }
                     }
@@ -641,43 +536,16 @@
               {
                 "l3extRsNodeL3OutAtt": {
                   "attributes": {
-                    "annotation": "orchestrator:terraform",
-                    "childAction": "",
-                    "configIssues": "",
-                    "extMngdBy": "",
-                    "forceResolve": "yes",
-                    "lcOwn": "local",
-                    "modTs": "2024-05-08T16:44:41.371-07:00",
-                    "monPolDn": "uni/tn-common/monepg-default",
-                    "rType": "mo",
-                    "rn": "rsnodeL3OutAtt-[topology/pod-1/node-103]",
                     "rtrId": "10.0.0.3",
                     "rtrIdLoopBack": "no",
-                    "state": "unformed",
-                    "stateQual": "none",
-                    "status": "",
                     "tCl": "fabricNode",
-                    "tDn": "topology/pod-1/node-103",
-                    "tType": "mo",
-                    "uid": "15374"
+                    "tDn": "topology/pod-1/node-103"
                   },
                   "children": [
                     {
                       "l3extLoopBackIfP": {
                         "attributes": {
-                          "addr": "10.0.0.103",
-                          "annotation": "",
-                          "childAction": "",
-                          "descr": "",
-                          "extMngdBy": "",
-                          "lcOwn": "local",
-                          "modTs": "2024-05-08T16:44:38.168-07:00",
-                          "monPolDn": "uni/tn-common/monepg-default",
-                          "name": "",
-                          "nameAlias": "",
-                          "rn": "lbp-[10.0.0.103]",
-                          "status": "",
-                          "uid": "15374"
+                          "addr": "10.0.0.103/32"
                         }
                       }
                     }
@@ -747,7 +615,7 @@
                     {
                       "l3extLoopBackIfP": {
                         "attributes": {
-                          "addr": "2001:1:2:3::104"
+                          "addr": "2001:1:2:3::104/128"
                         }
                       }
                     }
@@ -766,7 +634,7 @@
                     {
                       "l3extLoopBackIfP": {
                         "attributes": {
-                          "addr": "2001:1:2:3::103"
+                          "addr": "2001:1:2:3::103/128"
                         }
                       }
                     }

--- a/tests/l3out_overlapping_loopback_check/same_l3out_two_loopbacks.json
+++ b/tests/l3out_overlapping_loopback_check/same_l3out_two_loopbacks.json
@@ -1,0 +1,673 @@
+[
+  {
+    "l3extOut": {
+      "attributes": {
+        "annotation": "",
+        "childAction": "",
+        "descr": "",
+        "dn": "uni/tn-common/out-default",
+        "enforceRtctrl": "export",
+        "extMngdBy": "",
+        "lcOwn": "local",
+        "modTs": "2023-10-10T19:29:01.074-07:00",
+        "monPolDn": "uni/tn-common/monepg-default",
+        "name": "default",
+        "nameAlias": "",
+        "ownerKey": "",
+        "ownerTag": "",
+        "status": "",
+        "targetDscp": "unspecified",
+        "uid": "0"
+      },
+      "children": [
+        {
+          "l3extRsEctx": {
+            "attributes": {
+              "annotation": "",
+              "childAction": "",
+              "extMngdBy": "",
+              "forceResolve": "yes",
+              "lcOwn": "local",
+              "modTs": "2023-10-10T19:29:01.074-07:00",
+              "monPolDn": "uni/tn-common/monepg-default",
+              "rType": "mo",
+              "rn": "rsectx",
+              "state": "formed",
+              "stateQual": "default-target",
+              "status": "",
+              "tCl": "fvCtx",
+              "tContextDn": "",
+              "tDn": "uni/tn-common/ctx-default",
+              "tRn": "ctx-default",
+              "tType": "name",
+              "tnFvCtxName": "",
+              "uid": "0"
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "l3extOut": {
+      "attributes": {
+        "annotation": "orchestrator:terraform",
+        "childAction": "",
+        "descr": "",
+        "dn": "uni/tn-mgmt/out-INB_OSPF",
+        "enforceRtctrl": "export",
+        "extMngdBy": "",
+        "lcOwn": "local",
+        "modTs": "2024-04-11T12:06:10.596-07:00",
+        "monPolDn": "uni/tn-common/monepg-default",
+        "name": "INB_OSPF",
+        "nameAlias": "",
+        "ownerKey": "",
+        "ownerTag": "",
+        "status": "",
+        "targetDscp": "unspecified",
+        "uid": "15374"
+      },
+      "children": [
+        {
+          "l3extLNodeP": {
+            "attributes": {
+              "annotation": "orchestrator:terraform",
+              "childAction": "",
+              "configIssues": "",
+              "descr": "",
+              "extMngdBy": "",
+              "lcOwn": "local",
+              "modTs": "2024-04-11T12:06:13.262-07:00",
+              "monPolDn": "uni/tn-common/monepg-default",
+              "name": "INB_OSPF",
+              "nameAlias": "",
+              "ownerKey": "",
+              "ownerTag": "",
+              "rn": "lnodep-INB_OSPF",
+              "status": "",
+              "tag": "yellow-green",
+              "targetDscp": "unspecified",
+              "uid": "15374"
+            },
+            "children": [
+              {
+                "l3extLIfP": {
+                  "attributes": {
+                    "addr": "0.0.0.0",
+                    "annotation": "orchestrator:terraform",
+                    "childAction": "",
+                    "descr": "",
+                    "encap": "unknown",
+                    "extMngdBy": "",
+                    "lcOwn": "local",
+                    "modTs": "2024-04-11T12:06:18.258-07:00",
+                    "monPolDn": "uni/tn-common/monepg-default",
+                    "name": "INB_OSPF",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": "",
+                    "prio": "unspecified",
+                    "rn": "lifp-INB_OSPF",
+                    "status": "",
+                    "tag": "yellow-green",
+                    "targetDscp": "unspecified",
+                    "uid": "15374"
+                  },
+                  "children": [
+                    {
+                      "l3extRsPathL3OutAtt": {
+                        "attributes": {
+                          "addr": "10.10.10.1/24",
+                          "annotation": "orchestrator:terraform",
+                          "autostate": "disabled",
+                          "childAction": "",
+                          "configIssues": "",
+                          "descr": "",
+                          "encap": "vlan-10",
+                          "encapScope": "local",
+                          "extMngdBy": "",
+                          "forceResolve": "yes",
+                          "ifInstT": "sub-interface",
+                          "ipv6Dad": "enabled",
+                          "lcOwn": "local",
+                          "llAddr": "::",
+                          "mac": "00:22:BD:F8:19:FF",
+                          "modTs": "2024-04-11T12:06:19.600-07:00",
+                          "mode": "regular",
+                          "monPolDn": "uni/tn-common/monepg-default",
+                          "mtu": "9000",
+                          "rType": "mo",
+                          "rn": "rspathL3OutAtt-[topology/pod-1/paths-101/pathep-[eth1/13]]",
+                          "state": "unformed",
+                          "stateQual": "none",
+                          "status": "",
+                          "tCl": "fabricPathEp",
+                          "tDn": "topology/pod-1/paths-101/pathep-[eth1/13]",
+                          "tType": "mo",
+                          "targetDscp": "unspecified",
+                          "uid": "15374"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "l3extRsNodeL3OutAtt": {
+                  "attributes": {
+                    "annotation": "orchestrator:terraform",
+                    "childAction": "",
+                    "configIssues": "",
+                    "extMngdBy": "",
+                    "forceResolve": "yes",
+                    "lcOwn": "local",
+                    "modTs": "2024-04-11T12:06:14.870-07:00",
+                    "monPolDn": "uni/tn-common/monepg-default",
+                    "rType": "mo",
+                    "rn": "rsnodeL3OutAtt-[topology/pod-1/node-101]",
+                    "rtrId": "1.0.0.101",
+                    "rtrIdLoopBack": "no",
+                    "state": "unformed",
+                    "stateQual": "none",
+                    "status": "",
+                    "tCl": "fabricNode",
+                    "tDn": "topology/pod-1/node-101",
+                    "tType": "mo",
+                    "uid": "15374"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "l3extRsEctx": {
+            "attributes": {
+              "annotation": "orchestrator:terraform",
+              "childAction": "",
+              "extMngdBy": "",
+              "forceResolve": "yes",
+              "lcOwn": "local",
+              "modTs": "2024-04-11T12:06:11.387-07:00",
+              "monPolDn": "uni/tn-common/monepg-default",
+              "rType": "mo",
+              "rn": "rsectx",
+              "state": "formed",
+              "stateQual": "none",
+              "status": "",
+              "tCl": "fvCtx",
+              "tContextDn": "",
+              "tDn": "uni/tn-mgmt/ctx-inb",
+              "tRn": "ctx-inb",
+              "tType": "name",
+              "tnFvCtxName": "inb",
+              "uid": "0"
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "l3extOut": {
+      "attributes": {
+        "annotation": "orchestrator:terraform",
+        "childAction": "",
+        "descr": "",
+        "dn": "uni/tn-TK/out-OSPF",
+        "enforceRtctrl": "export",
+        "extMngdBy": "",
+        "lcOwn": "local",
+        "modTs": "2024-04-12T09:55:53.592-07:00",
+        "monPolDn": "uni/tn-common/monepg-default",
+        "name": "OSPF",
+        "nameAlias": "",
+        "ownerKey": "",
+        "ownerTag": "",
+        "status": "",
+        "targetDscp": "unspecified",
+        "uid": "15374"
+      },
+      "children": [
+        {
+          "l3extLNodeP": {
+            "attributes": {
+              "annotation": "orchestrator:terraform",
+              "childAction": "",
+              "configIssues": "",
+              "descr": "",
+              "extMngdBy": "",
+              "lcOwn": "local",
+              "modTs": "2024-04-12T09:55:55.504-07:00",
+              "monPolDn": "uni/tn-common/monepg-default",
+              "name": "IPv4",
+              "nameAlias": "",
+              "ownerKey": "",
+              "ownerTag": "",
+              "rn": "lnodep-IPv4",
+              "status": "",
+              "tag": "yellow-green",
+              "targetDscp": "unspecified",
+              "uid": "15374"
+            },
+            "children": [
+              {
+                "l3extLIfP": {
+                  "attributes": {
+                    "addr": "0.0.0.0",
+                    "annotation": "orchestrator:terraform",
+                    "childAction": "",
+                    "descr": "",
+                    "encap": "unknown",
+                    "extMngdBy": "",
+                    "lcOwn": "local",
+                    "modTs": "2024-04-12T09:56:01.299-07:00",
+                    "monPolDn": "uni/tn-common/monepg-default",
+                    "name": "IFP",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": "",
+                    "prio": "unspecified",
+                    "rn": "lifp-IFP",
+                    "status": "",
+                    "tag": "yellow-green",
+                    "targetDscp": "unspecified",
+                    "uid": "15374"
+                  },
+                  "children": [
+                    {
+                      "l3extRsPathL3OutAtt": {
+                        "attributes": {
+                          "addr": "0.0.0.0",
+                          "annotation": "orchestrator:terraform",
+                          "autostate": "disabled",
+                          "childAction": "",
+                          "configIssues": "",
+                          "descr": "",
+                          "encap": "vlan-1053",
+                          "encapScope": "local",
+                          "extMngdBy": "",
+                          "forceResolve": "yes",
+                          "ifInstT": "ext-svi",
+                          "ipv6Dad": "enabled",
+                          "lcOwn": "local",
+                          "llAddr": "::",
+                          "mac": "00:22:BD:F8:19:FF",
+                          "modTs": "2024-04-12T09:56:04.207-07:00",
+                          "mode": "regular",
+                          "monPolDn": "uni/tn-common/monepg-default",
+                          "mtu": "9000",
+                          "rType": "mo",
+                          "rn": "rspathL3OutAtt-[topology/pod-1/protpaths-103-104/pathep-[N9K_VPC_3-4_13]]",
+                          "state": "unformed",
+                          "stateQual": "none",
+                          "status": "",
+                          "tCl": "fabricPathEp",
+                          "tDn": "topology/pod-1/protpaths-103-104/pathep-[N9K_VPC_3-4_13]",
+                          "tType": "mo",
+                          "targetDscp": "unspecified",
+                          "uid": "15374"
+                        },
+                        "children": [
+                          {
+                            "l3extMember": {
+                              "attributes": {
+                                "addr": "10.53.0.4/24",
+                                "annotation": "orchestrator:terraform",
+                                "childAction": "",
+                                "descr": "",
+                                "extMngdBy": "",
+                                "ipv6Dad": "enabled",
+                                "lcOwn": "local",
+                                "llAddr": "::",
+                                "modTs": "2024-05-08T12:56:24.560-07:00",
+                                "monPolDn": "uni/tn-common/monepg-default",
+                                "name": "",
+                                "nameAlias": "",
+                                "rn": "mem-B",
+                                "side": "B",
+                                "status": "",
+                                "uid": "15374"
+                              }
+                            }
+                          },
+                          {
+                            "l3extMember": {
+                              "attributes": {
+                                "addr": "10.53.0.3/24",
+                                "annotation": "orchestrator:terraform",
+                                "childAction": "",
+                                "descr": "",
+                                "extMngdBy": "",
+                                "ipv6Dad": "enabled",
+                                "lcOwn": "local",
+                                "llAddr": "::",
+                                "modTs": "2024-05-08T12:56:24.560-07:00",
+                                "monPolDn": "uni/tn-common/monepg-default",
+                                "name": "",
+                                "nameAlias": "",
+                                "rn": "mem-A",
+                                "side": "A",
+                                "status": "",
+                                "uid": "15374"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "l3extRsNodeL3OutAtt": {
+                  "attributes": {
+                    "annotation": "orchestrator:terraform",
+                    "childAction": "",
+                    "configIssues": "",
+                    "extMngdBy": "",
+                    "forceResolve": "yes",
+                    "lcOwn": "local",
+                    "modTs": "2024-04-12T09:55:56.480-07:00",
+                    "monPolDn": "uni/tn-common/monepg-default",
+                    "rType": "mo",
+                    "rn": "rsnodeL3OutAtt-[topology/pod-1/node-103]",
+                    "rtrId": "10.0.0.3",
+                    "rtrIdLoopBack": "no",
+                    "state": "unformed",
+                    "stateQual": "none",
+                    "status": "",
+                    "tCl": "fabricNode",
+                    "tDn": "topology/pod-1/node-103",
+                    "tType": "mo",
+                    "uid": "15374"
+                  }
+                }
+              },
+              {
+                "l3extRsNodeL3OutAtt": {
+                  "attributes": {
+                    "annotation": "orchestrator:terraform",
+                    "childAction": "",
+                    "configIssues": "",
+                    "extMngdBy": "",
+                    "forceResolve": "yes",
+                    "lcOwn": "local",
+                    "modTs": "2024-04-12T09:55:56.392-07:00",
+                    "monPolDn": "uni/tn-common/monepg-default",
+                    "rType": "mo",
+                    "rn": "rsnodeL3OutAtt-[topology/pod-1/node-104]",
+                    "rtrId": "10.0.0.4",
+                    "rtrIdLoopBack": "no",
+                    "state": "unformed",
+                    "stateQual": "none",
+                    "status": "",
+                    "tCl": "fabricNode",
+                    "tDn": "topology/pod-1/node-104",
+                    "tType": "mo",
+                    "uid": "15374"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "l3extRsEctx": {
+            "attributes": {
+              "annotation": "orchestrator:terraform",
+              "childAction": "",
+              "extMngdBy": "",
+              "forceResolve": "yes",
+              "lcOwn": "local",
+              "modTs": "2024-04-12T09:55:54.049-07:00",
+              "monPolDn": "uni/tn-common/monepg-default",
+              "rType": "mo",
+              "rn": "rsectx",
+              "state": "formed",
+              "stateQual": "none",
+              "status": "",
+              "tCl": "fvCtx",
+              "tContextDn": "",
+              "tDn": "uni/tn-TK/ctx-VRFA",
+              "tRn": "ctx-VRFA",
+              "tType": "name",
+              "tnFvCtxName": "VRFA",
+              "uid": "0"
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "l3extOut": {
+      "attributes": {
+        "annotation": "orchestrator:terraform",
+        "childAction": "",
+        "descr": "",
+        "dn": "uni/tn-TK/out-BGP",
+        "enforceRtctrl": "export",
+        "extMngdBy": "",
+        "lcOwn": "local",
+        "modTs": "2024-04-12T09:55:53.557-07:00",
+        "monPolDn": "uni/tn-common/monepg-default",
+        "name": "BGP",
+        "nameAlias": "",
+        "ownerKey": "",
+        "ownerTag": "",
+        "status": "",
+        "targetDscp": "unspecified",
+        "uid": "15374"
+      },
+      "children": [
+        {
+          "l3extLNodeP": {
+            "attributes": {
+              "name": "IPv4"
+            },
+            "children": [
+              {
+                "l3extLIfP": {
+                  "attributes": {
+                    "name": "IFP"
+                  },
+                  "children": [
+                    {
+                      "l3extRsPathL3OutAtt": {
+                        "attributes": {
+                          "addr": "0.0.0.0",
+                          "encap": "vlan-1051",
+                          "encapScope": "local",
+                          "ifInstT": "ext-svi",
+                          "ipv6Dad": "enabled",
+                          "llAddr": "::",
+                          "mode": "regular",
+                          "tCl": "fabricPathEp",
+                          "tDn": "topology/pod-1/protpaths-103-104/pathep-[N9K_VPC_3-4_13]"
+                        },
+                        "children": [
+                          {
+                            "l3extMember": {
+                              "attributes": {
+                                "addr": "10.0.0.40/25",
+                                "ipv6Dad": "enabled",
+                                "llAddr": "::",
+                                "side": "B"
+                              }
+                            }
+                          },
+                          {
+                            "l3extMember": {
+                              "attributes": {
+                                "addr": "10.0.0.30/25",
+                                "ipv6Dad": "enabled",
+                                "llAddr": "::",
+                                "side": "A"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "l3extRsNodeL3OutAtt": {
+                  "attributes": {
+                    "rtrId": "10.0.0.4",
+                    "rtrIdLoopBack": "no",
+                    "tCl": "fabricNode",
+                    "tDn": "topology/pod-1/node-104"
+                  },
+                  "children": [
+                    {
+                      "l3extLoopBackIfP": {
+                        "attributes": {
+                          "addr": "10.0.0.104/32"
+                        }
+                      }
+                    },
+                    {
+                      "l3extLoopBackIfP": {
+                        "attributes": {
+                          "addr": "2001:1:2:3::104/128"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "l3extRsNodeL3OutAtt": {
+                  "attributes": {
+                    "rtrId": "10.0.0.3",
+                    "rtrIdLoopBack": "no",
+                    "tCl": "fabricNode",
+                    "tDn": "topology/pod-1/node-103"
+                  },
+                  "children": [
+                    {
+                      "l3extLoopBackIfP": {
+                        "attributes": {
+                          "addr": "10.0.0.103/32"
+                        }
+                      }
+                    },
+                    {
+                      "l3extLoopBackIfP": {
+                        "attributes": {
+                          "addr": "2001:1:2:3::103/128"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "l3extLNodeP": {
+            "attributes": {
+              "name": "IPv6"
+            },
+            "children": [
+              {
+                "l3extLIfP": {
+                  "attributes": {
+                    "name": "IFP"
+                  },
+                  "children": [
+                    {
+                      "l3extRsPathL3OutAtt": {
+                        "attributes": {
+                          "addr": "0.0.0.0",
+                          "ipv6Dad": "enabled",
+                          "llAddr": "::",
+                          "tCl": "fabricPathEp",
+                          "tDn": "topology/pod-1/protpaths-103-104/pathep-[N9K_VPC_3-4_13]"
+                        },
+                        "children": [
+                          {
+                            "l3extMember": {
+                              "attributes": {
+                                "addr": "2001:1:2:3::40/64",
+                                "ipv6Dad": "enabled",
+                                "llAddr": "::",
+                                "side": "B"
+                              }
+                            }
+                          },
+                          {
+                            "l3extMember": {
+                              "attributes": {
+                                "addr": "2001:1:2:3::30/64",
+                                "ipv6Dad": "enabled",
+                                "llAddr": "::",
+                                "side": "A"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "l3extRsNodeL3OutAtt": {
+                  "attributes": {
+                    "rtrId": "10.0.0.4",
+                    "rtrIdLoopBack": "no",
+                    "tCl": "fabricNode",
+                    "tDn": "topology/pod-1/node-104"
+                  },
+                  "children": []
+                }
+              },
+              {
+                "l3extRsNodeL3OutAtt": {
+                  "attributes": {
+                    "rtrId": "10.0.0.3",
+                    "rtrIdLoopBack": "no",
+                    "tCl": "fabricNode",
+                    "tDn": "topology/pod-1/node-103"
+                  },
+                  "children": []
+                }
+              }
+            ]
+          }
+        },
+        {
+          "l3extRsEctx": {
+            "attributes": {
+              "annotation": "orchestrator:terraform",
+              "childAction": "",
+              "extMngdBy": "",
+              "forceResolve": "yes",
+              "lcOwn": "local",
+              "modTs": "2024-04-12T09:55:54.049-07:00",
+              "monPolDn": "uni/tn-common/monepg-default",
+              "rType": "mo",
+              "rn": "rsectx",
+              "state": "formed",
+              "stateQual": "none",
+              "status": "",
+              "tCl": "fvCtx",
+              "tContextDn": "",
+              "tDn": "uni/tn-TK/ctx-VRFA",
+              "tRn": "ctx-VRFA",
+              "tType": "name",
+              "tnFvCtxName": "VRFA",
+              "uid": "0"
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/tests/l3out_overlapping_loopback_check/test_l3out_overlapping_loopback_check.py
+++ b/tests/l3out_overlapping_loopback_check/test_l3out_overlapping_loopback_check.py
@@ -27,8 +27,10 @@ api += '&rsp-subtree-class=l3extRsEctx,l3extRsNodeL3OutAtt,l3extLoopBackIfP,l3ex
         ({api: read_data(dir, "same_l3out_rtrId_non_vpc.json")}, script.FAIL_O),
         # Overlap within the same L3Out - Router ID as loopback (VPC)
         ({api: read_data(dir, "same_l3out_rtrId.json")}, script.FAIL_O),
-        # Overlap within the same L3Out - Explicit loopback (VPC)
+        # Overlap within the same L3Out - Explicit loopback (VPC) - IPv4/v6
         ({api: read_data(dir, "same_l3out_loopback.json")}, script.FAIL_O),
+        # Overlap within the same L3Out - Explicit loopback with subnet mask 32/128 (VPC) - IPv4/v6
+        ({api: read_data(dir, "same_l3out_loopback_with_subnet_mask.json")}, script.FAIL_O),
         # Overlap within the same L3Out - Explicit loopback and Router ID as loopback (VPC)
         ({api: read_data(dir, "same_l3out_loopback_and_rtrId.json")}, script.FAIL_O),
         # Overlap across different L3Outs - Router ID as loopback (VPC)

--- a/tests/l3out_overlapping_loopback_check/test_l3out_overlapping_loopback_check.py
+++ b/tests/l3out_overlapping_loopback_check/test_l3out_overlapping_loopback_check.py
@@ -29,7 +29,9 @@ api += '&rsp-subtree-class=l3extRsEctx,l3extRsNodeL3OutAtt,l3extLoopBackIfP,l3ex
         ({api: read_data(dir, "same_l3out_rtrId.json")}, script.FAIL_O),
         # Overlap within the same L3Out - Explicit loopback (VPC) - IPv4/v6
         ({api: read_data(dir, "same_l3out_loopback.json")}, script.FAIL_O),
-        # Overlap within the same L3Out - Explicit loopback with subnet mask 32/128 (VPC) - IPv4/v6
+        # Overlap within the same L3Out - Explicit loopback (VPC) - IPv4/v6 - 2 l3extLoopBackIfP's under same l3extRsNodeL3OutAtt.
+        ({api: read_data(dir, "same_l3out_two_loopbacks.json")}, script.FAIL_O),
+        # Overlap within the same L3Out - Explicit loopback with subnet mask /32,/128 (VPC) - IPv4/v6
         ({api: read_data(dir, "same_l3out_loopback_with_subnet_mask.json")}, script.FAIL_O),
         # Overlap within the same L3Out - Explicit loopback and Router ID as loopback (VPC)
         ({api: read_data(dir, "same_l3out_loopback_and_rtrId.json")}, script.FAIL_O),


### PR DESCRIPTION
* Fix issue #180 by striping `/32` or `/128` (if any) in the loopback.
* Handle a case when there are multiple loopback IP addresses on the same node in the same VRF.
* `ip_in_subnet()` of class `IPAddress` should raise `ValueError` when the provided IP address has a subnet.

<details>
<summary>pytest output:</summary>

```
[Check  1/1] L3Out Loopback IP Overlap With L3Out Interfaces...                                                                      PASS
[Check  1/1] L3Out Loopback IP Overlap With L3Out Interfaces...                                                                      PASS
[Check  1/1] L3Out Loopback IP Overlap With L3Out Interfaces...                                                   FAIL - OUTAGE WARNING!!
  Tenant:VRF  Node ID  Loopback IP (Tenant:L3Out:NodeP)  Interface IP (Tenant:L3Out:NodeP:IFP)
  ----------  -------  --------------------------------  -------------------------------------
  TK:VRFA     103      10.0.0.3 (TK:BGP:IPv4)            10.0.0.30/24 (TK:BGP:IPv4:IFP)

  Recommended Action: Change either the loopback or L3Out interface IP subnet to avoid overlap.
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#l3out-loopback-ip-overlap-with-l3out-interfaces


[Check  1/1] L3Out Loopback IP Overlap With L3Out Interfaces...                                                   FAIL - OUTAGE WARNING!!
  Tenant:VRF  Node ID  Loopback IP (Tenant:L3Out:NodeP)  Interface IP (Tenant:L3Out:NodeP:IFP)
  ----------  -------  --------------------------------  -------------------------------------
  TK:VRFA     103      10.0.0.3 (TK:BGP:IPv4)            10.0.0.30/25 (TK:BGP:IPv4:IFP)
  TK:VRFA     104      10.0.0.4 (TK:BGP:IPv4)            10.0.0.40/25 (TK:BGP:IPv4:IFP)

  Recommended Action: Change either the loopback or L3Out interface IP subnet to avoid overlap.
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#l3out-loopback-ip-overlap-with-l3out-interfaces


[Check  1/1] L3Out Loopback IP Overlap With L3Out Interfaces...                                                   FAIL - OUTAGE WARNING!!
  Tenant:VRF  Node ID  Loopback IP (Tenant:L3Out:NodeP)  Interface IP (Tenant:L3Out:NodeP:IFP)
  ----------  -------  --------------------------------  -------------------------------------
  TK:VRFA     103      10.0.0.103 (TK:BGP:IPv4)          10.0.0.30/25 (TK:BGP:IPv4:IFP)
  TK:VRFA     103      2001:1:2:3::103 (TK:BGP:IPv6)     2001:1:2:3::30/64 (TK:BGP:IPv6:IFP)
  TK:VRFA     104      10.0.0.104 (TK:BGP:IPv4)          10.0.0.40/25 (TK:BGP:IPv4:IFP)
  TK:VRFA     104      2001:1:2:3::104 (TK:BGP:IPv6)     2001:1:2:3::40/64 (TK:BGP:IPv6:IFP)

  Recommended Action: Change either the loopback or L3Out interface IP subnet to avoid overlap.
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#l3out-loopback-ip-overlap-with-l3out-interfaces


[Check  1/1] L3Out Loopback IP Overlap With L3Out Interfaces...                                                   FAIL - OUTAGE WARNING!!
  Tenant:VRF  Node ID  Loopback IP (Tenant:L3Out:NodeP)  Interface IP (Tenant:L3Out:NodeP:IFP)
  ----------  -------  --------------------------------  -------------------------------------
  TK:VRFA     103      10.0.0.103 (TK:BGP:IPv4)          10.0.0.30/25 (TK:BGP:IPv4:IFP)
  TK:VRFA     103      2001:1:2:3::103 (TK:BGP:IPv4)     2001:1:2:3::30/64 (TK:BGP:IPv6:IFP)
  TK:VRFA     104      10.0.0.104 (TK:BGP:IPv4)          10.0.0.40/25 (TK:BGP:IPv4:IFP)
  TK:VRFA     104      2001:1:2:3::104 (TK:BGP:IPv4)     2001:1:2:3::40/64 (TK:BGP:IPv6:IFP)

  Recommended Action: Change either the loopback or L3Out interface IP subnet to avoid overlap.
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#l3out-loopback-ip-overlap-with-l3out-interfaces


[Check  1/1] L3Out Loopback IP Overlap With L3Out Interfaces...                                                   FAIL - OUTAGE WARNING!!
  Tenant:VRF  Node ID  Loopback IP (Tenant:L3Out:NodeP)  Interface IP (Tenant:L3Out:NodeP:IFP)
  ----------  -------  --------------------------------  -------------------------------------
  TK:VRFA     103      10.0.0.103 (TK:BGP:IPv4)          10.0.0.30/25 (TK:BGP:IPv4:IFP)
  TK:VRFA     103      2001:1:2:3::103 (TK:BGP:IPv6)     2001:1:2:3::30/64 (TK:BGP:IPv6:IFP)
  TK:VRFA     104      10.0.0.104 (TK:BGP:IPv4)          10.0.0.40/25 (TK:BGP:IPv4:IFP)
  TK:VRFA     104      2001:1:2:3::104 (TK:BGP:IPv6)     2001:1:2:3::40/64 (TK:BGP:IPv6:IFP)

  Recommended Action: Change either the loopback or L3Out interface IP subnet to avoid overlap.
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#l3out-loopback-ip-overlap-with-l3out-interfaces


[Check  1/1] L3Out Loopback IP Overlap With L3Out Interfaces...                                                   FAIL - OUTAGE WARNING!!
  Tenant:VRF  Node ID  Loopback IP (Tenant:L3Out:NodeP)  Interface IP (Tenant:L3Out:NodeP:IFP)
  ----------  -------  --------------------------------  -------------------------------------
  TK:VRFA     103      10.0.0.103 (TK:BGP:IPv4)          10.0.0.30/25 (TK:BGP:IPv4:IFP)
  TK:VRFA     104      10.0.0.4 (TK:BGP:IPv4)            10.0.0.40/25 (TK:BGP:IPv4:IFP)

  Recommended Action: Change either the loopback or L3Out interface IP subnet to avoid overlap.
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#l3out-loopback-ip-overlap-with-l3out-interfaces


[Check  1/1] L3Out Loopback IP Overlap With L3Out Interfaces...                                                   FAIL - OUTAGE WARNING!!
  Tenant:VRF  Node ID  Loopback IP (Tenant:L3Out:NodeP)  Interface IP (Tenant:L3Out:NodeP:IFP)
  ----------  -------  --------------------------------  -------------------------------------
  TK:VRFA     103      10.0.0.3 (TK:OSPF:IPv4)           10.0.0.30/24 (TK:BGP:IPv4:IFP)
  TK:VRFA     104      10.0.0.4 (TK:OSPF:IPv4)           10.0.0.40/24 (TK:BGP:IPv4:IFP)

  Recommended Action: Change either the loopback or L3Out interface IP subnet to avoid overlap.
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#l3out-loopback-ip-overlap-with-l3out-interfaces


[Check  1/1] L3Out Loopback IP Overlap With L3Out Interfaces...                                                   FAIL - OUTAGE WARNING!!
  Tenant:VRF  Node ID  Loopback IP (Tenant:L3Out:NodeP)  Interface IP (Tenant:L3Out:NodeP:IFP)
  ----------  -------  --------------------------------  -------------------------------------
  TK:VRFA     103      10.0.0.103 (TK:OSPF:IPv4)         10.0.0.30/24 (TK:BGP:IPv4:IFP)
  TK:VRFA     104      10.0.0.104 (TK:OSPF:IPv4)         10.0.0.40/24 (TK:BGP:IPv4:IFP)

  Recommended Action: Change either the loopback or L3Out interface IP subnet to avoid overlap.
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#l3out-loopback-ip-overlap-with-l3out-interfaces


[Check  1/1] L3Out Loopback IP Overlap With L3Out Interfaces...                                                   FAIL - OUTAGE WARNING!!
  Tenant:VRF  Node ID  Loopback IP (Tenant:L3Out:NodeP)  Interface IP (Tenant:L3Out:NodeP:IFP)
  ----------  -------  --------------------------------  -------------------------------------
  TK:VRFA     103      10.0.0.3 (TK:OSPF:IPv4)           10.0.0.30/24 (TK:BGP:IPv4:IFP)
  TK:VRFA     104      10.0.0.104 (TK:OSPF:IPv4)         10.0.0.40/24 (TK:BGP:IPv4:IFP)

  Recommended Action: Change either the loopback or L3Out interface IP subnet to avoid overlap.
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#l3out-loopback-ip-overlap-with-l3out-interfaces
```

</details>

Integration tests passed.


The update error when a subnet is passed along with the IP in `ip_in_subnet()`.
```
cls = <class 'aci-preupgrade-validation-script.IPAddress'>, ip = '2001:1:2:3::104/128', subnet = '10.53.0.4/24'

    @classmethod
    def ip_in_subnet(cls, ip, subnet):                                                                                                             if "/" in ip:
>           raise ValueError(                                                                                                                              "IP address {} should not have a subnet mask".format(ip)
            )
E           ValueError: IP address 2001:1:2:3::104/128 should not have a subnet mask
```