### PR TITLE
`fabric_port_down_check` show lifecycle

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -3787,8 +3787,8 @@ def fabric_port_down_check(index, total_checks, **kwargs):
     title = 'Fabric Port is Down (F1394 ethpm-if-port-down-fabric)'
     result = FAIL_O
     msg = ''
-    headers = ["Pod", "Node", "Int", "Reason"]
-    unformatted_headers = ['dn', 'Fault Description']
+    headers = ["Pod", "Node", "Int", "Reason", "Lifecycle"]
+    unformatted_headers = ['dn', 'Fault Description', 'Lifecycle']
     unformatted_data = []
     data = []
     recommended_action = 'Identify if these ports are needed for redundancy and reason for being down'
@@ -3809,9 +3809,10 @@ def fabric_port_down_check(index, total_checks, **kwargs):
             nodeid = m.group('node')
             port = m.group('int')
             reason = faultInst['faultInst']['attributes']['descr'].split("reason:")[1]
-            data.append([podid, nodeid, port, reason])
+            lc = faultInst['faultInst']['attributes']['lc']
+            data.append([podid, nodeid, port, reason, lc])
         else:
-            unformatted_data.append([faultInst['faultInst']['attributes']['dn'], faultInst['faultInst']['attributes']['descr']])
+            unformatted_data.append([faultInst['faultInst']['attributes']['dn'], faultInst['faultInst']['attributes']['descr'], faultInst['faultInst']['attributes']['lc']])
 
     if not data and not unformatted_data:
         result = PASS

--- a/tests/fabric_port_down_check/faultInst_pos.json
+++ b/tests/fabric_port_down_check/faultInst_pos.json
@@ -4,7 +4,8 @@
       "attributes": {
         "descr": "Port is down, reason:err-disabled-link-flaps(err-disabled), used by:Fabric",
         "dn": "topology/pod-1/node-105/sys/phys-[eth1/53]/phys/fault-F1394",
-        "rule": "ethpm-if-port-down-fabric"
+        "rule": "ethpm-if-port-down-fabric",
+        "lc": "raised"
       }
     }
   },
@@ -13,7 +14,8 @@
       "attributes": {
         "descr": "Port is down, reason:linkNotConnected(connected), used by:Fabric",
         "dn": "topology/pod-1/node-101/sys/phys-[eth1/53]/phys/fault-F1394",
-        "rule": "ethpm-if-port-down-fabric"
+        "rule": "ethpm-if-port-down-fabric",
+        "lc": "soaking"
       }
     }
   },
@@ -22,7 +24,8 @@
       "attributes": {
         "descr": "Port is down, reason:linkNotConnected(connected), used by:Fabric",
         "dn": "topology/pod-1/node-102/sys/phys-eth1/53/phys/fault-F1394",
-        "rule": "ethpm-if-port-down-fabric"
+        "rule": "ethpm-if-port-down-fabric",
+        "lc": "retaining"
       }
     }
   }


### PR DESCRIPTION
pytest output:
```
[Check  1/1] Fabric Port is Down (F1394 ethpm-if-port-down-fabric)...                                             FAIL - OUTAGE WARNING!!
  Pod  Node  Int      Reason                                                 Lifecycle
  ---  ----  ---      ------                                                 ---------
  1    101   eth1/53  linkNotConnected(connected), used by:Fabric            soaking
  1    105   eth1/53  err-disabled-link-flaps(err-disabled), used by:Fabric  raised
  dn                                                         Fault Description                                                 Lifecycle
  --                                                         -----------------                                                 ---------
  topology/pod-1/node-102/sys/phys-eth1/53/phys/fault-F1394  Port is down, reason:linkNotConnected(connected), used by:Fabric  retaining

  Recommended Action: Identify if these ports are needed for redundancy and reason for being down
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations#fabric-port-is-down


[Check  1/1] Fabric Port is Down (F1394 ethpm-if-port-down-fabric)...                                                                PASS
