### PR TITLE
Improve prefix already inuse check

### DIFF
--- a/tests/prefix_already_in_use_check/faultInst_F0467_prefix-entry-already-in-use_new.json
+++ b/tests/prefix_already_in_use_check/faultInst_F0467_prefix-entry-already-in-use_new.json
@@ -2,35 +2,67 @@
   {
     "faultInst": {
       "attributes": {
-        "ack": "no",
-        "alert": "no",
-        "cause": "configuration-failed",
-        "changeSet": "configQual:prefix-entry-already-in-use, configSt:failed-to-apply, debugMessage:prefix-entry-already-in-use: Prefix entry sys/ctx-[vxlan-2457600]/pfx-[20.51.0.0/24] is in use;, temporaryError:no",
-        "childAction": "",
+        "changeSet": "configQual:prefix-entry-already-in-use, configSt:failed-to-apply, debugMessage:prefix-entry-already-in-use: Prefix entry sys/ctx-[vxlan-2457600]/pfx-[10.0.0.0/8] is in use;, temporaryError:no",
         "code": "F0467",
-        "created": "2023-08-15T22:08:23.666-07:00",
         "delegated": "yes",
-        "descr": "Configuration failed for uni/tn-TK/out-OSPF/instP-EPG1 due to Prefix Entry Already Used in Another EPG, debug message: prefix-entry-already-in-use: Prefix entry sys/ctx-[vxlan-2457600]/pfx-[20.51.0.0/24] is in use;",
-        "dn": "topology/pod-2/node-103/local/svc-policyelem-id-0/uni/epp/rtd-[uni/tn-TK/out-OSPF/instP-EPG1]/nwissues/fault-F0467",
-        "domain": "tenant",
-        "extMngdBy": "undefined",
-        "highestSeverity": "minor",
-        "lastTransition": "2023-08-15T22:10:37.185-07:00",
-        "lc": "raised",
-        "modTs": "never",
-        "occur": "1",
-        "origSeverity": "minor",
-        "prevSeverity": "minor",
-        "rn": "fault-F0467",
-        "rule": "fv-nw-issues-config-failed",
-        "severity": "minor",
-        "status": "",
-        "subject": "management",
-        "title": "",
-        "type": "config",
-        "userdom": "all"
+        "descr": "Configuration failed for uni/tn-TK/out-BGP/instP-EPG2 due to Prefix Entry Already Used in Another EPG, debug message: prefix-entry-already-in-use: Prefix entry sys/ctx-[vxlan-2457600]/pfx-[10.0.0.0/8] is in use;",
+        "dn": "topology/pod-2/node-103/local/svc-policyelem-id-0/uni/epp/rtd-[uni/tn-TK/out-BGP/instP-EPG2]/nwissues/fault-F0467"
+      }
+    }
+  },
+  {
+    "faultInst": {
+      "attributes": {
+        "changeSet": "configQual:prefix-entry-already-in-use, configSt:failed-to-apply, debugMessage:prefix-entry-already-in-use: Prefix entry sys/ctx-[vxlan-2457600]/pfx-[10.0.0.0/8] is in use;, temporaryError:no",
+        "code": "F0467",
+        "delegated": "yes",
+        "descr": "Configuration failed for uni/tn-TK/out-OSPF/instP-EPG1 due to Prefix Entry Already Used in Another EPG, debug message: prefix-entry-already-in-use: Prefix entry sys/ctx-[vxlan-2457600]/pfx-[10.0.0.0/8] is in use;",
+        "dn": "topology/pod-2/node-103/local/svc-policyelem-id-0/uni/epp/rtd-[uni/tn-TK/out-OSPF/instP-EPG1]/nwissues/fault-F0467"
+      }
+    }
+  },
+  {
+    "faultInst": {
+      "attributes": {
+        "changeSet": "configQual:prefix-entry-already-in-use, configSt:failed-to-apply, debugMessage:prefix-entry-already-in-use: Prefix entry sys/ctx-[vxlan-2457600]/pfx-[10.0.0.0/8] is in use;, temporaryError:no",
+        "code": "F0467",
+        "delegated": "yes",
+        "descr": "Configuration failed for uni/tn-TK/out-EIGRP/instP-EPG1 due to Prefix Entry Already Used in Another EPG, debug message: prefix-entry-already-in-use: Prefix entry sys/ctx-[vxlan-2457600]/pfx-[10.0.0.0/8] is in use;",
+        "dn": "topology/pod-2/node-103/local/svc-policyelem-id-0/uni/epp/rtd-[uni/tn-TK/out-EIGRP/instP-EPG1]/nwissues/fault-F0467"
+      }
+    }
+  },
+  {
+    "faultInst": {
+      "attributes": {
+        "changeSet": "configQual:prefix-entry-already-in-use, configSt:failed-to-apply, debugMessage:prefix-entry-already-in-use: Prefix entry sys/ctx-[vxlan-2457600]/pfx-[10.0.0.0/8] is in use;, temporaryError:no",
+        "code": "F0467",
+        "delegated": "yes",
+        "descr": "Configuration failed for uni/tn-TK/out-BGP/instP-EPG2 due to Prefix Entry Already Used in Another EPG, debug message: prefix-entry-already-in-use: Prefix entry sys/ctx-[vxlan-2457600]/pfx-[10.0.0.0/8] is in use;",
+        "dn": "topology/pod-2/node-104/local/svc-policyelem-id-0/uni/epp/rtd-[uni/tn-TK/out-BGP/instP-EPG2]/nwissues/fault-F0467"
+      }
+    }
+  },
+  {
+    "faultInst": {
+      "attributes": {
+        "changeSet": "configQual:prefix-entry-already-in-use, configSt:failed-to-apply, debugMessage:prefix-entry-already-in-use: Prefix entry sys/ctx-[vxlan-2457600]/pfx-[10.0.0.0/8] is in use;, temporaryError:no",
+        "code": "F0467",
+        "delegated": "yes",
+        "descr": "Configuration failed for uni/tn-TK/out-OSPF/instP-EPG1 due to Prefix Entry Already Used in Another EPG, debug message: prefix-entry-already-in-use: Prefix entry sys/ctx-[vxlan-2457600]/pfx-[10.0.0.0/8] is in use;",
+        "dn": "topology/pod-2/node-104/local/svc-policyelem-id-0/uni/epp/rtd-[uni/tn-TK/out-OSPF/instP-EPG1]/nwissues/fault-F0467"
+      }
+    }
+  },
+  {
+    "faultInst": {
+      "attributes": {
+        "changeSet": "configQual:prefix-entry-already-in-use, configSt:failed-to-apply, debugMessage:prefix-entry-already-in-use: Prefix entry sys/ctx-[vxlan-2457600]/pfx-[10.0.0.0/8] is in use;, temporaryError:no",
+        "code": "F0467",
+        "delegated": "yes",
+        "descr": "Configuration failed for uni/tn-TK/out-EIGRP/instP-EPG1 due to Prefix Entry Already Used in Another EPG, debug message: prefix-entry-already-in-use: Prefix entry sys/ctx-[vxlan-2457600]/pfx-[10.0.0.0/8] is in use;",
+        "dn": "topology/pod-2/node-104/local/svc-policyelem-id-0/uni/epp/rtd-[uni/tn-TK/out-EIGRP/instP-EPG1]/nwissues/fault-F0467"
       }
     }
   }
 ]
-

--- a/tests/prefix_already_in_use_check/faultInst_F0467_prefix-entry-already-in-use_old.json
+++ b/tests/prefix_already_in_use_check/faultInst_F0467_prefix-entry-already-in-use_old.json
@@ -2,30 +2,66 @@
   {
     "faultInst": {
       "attributes": {
-        "dn": "topology/pod-1/node-103/local/svc-policyelem-id-0/uni/epp/rtd-[uni/tn-TK/out-BGP/instP-EPG1]/nwissues/fault-F0467",
-        "domain": "tenant",
+        "dn": "topology/pod-1/node-103/local/svc-policyelem-id-0/uni/epp/rtd-[uni/tn-TK/out-BGP/instP-EPG2]/nwissues/fault-F0467",
         "code": "F0467",
-        "extMngdBy": "undefined",
-        "occur": "1",
-        "subject": "management",
-        "severity": "minor",
-        "descr": "Configuration failed for uni/tn-TK/out-BGP/instP-EPG1 due to Prefix Entry Already Used in Another EPG, debug message: ",
-        "modTs": "never",
-        "rn": "fault-F0467",
-        "childAction": "",
-        "type": "config",
-        "status": "",
-        "prevSeverity": "minor",
-        "origSeverity": "minor",
-        "highestSeverity": "minor",
+        "descr": "Configuration failed for uni/tn-TK/out-BGP/instP-EPG2 due to Prefix Entry Already Used in Another EPG, debug message: ",
         "delegated": "yes",
-        "lc": "raised",
-        "changeSet": "configQual:prefix-entry-already-in-use, configSt:failed-to-apply, temporaryError:no",
-        "created": "2023-08-14T21:44:38.740-07:00",
-        "ack": "no",
-        "cause": "configuration-failed",
-        "rule": "fv-nw-issues-config-failed",
-        "lastTransition": "2023-08-14T21:46:40.883-07:00"
+        "changeSet": "configQual:prefix-entry-already-in-use, configSt:failed-to-apply, temporaryError:no"
+      }
+    }
+  },
+  {
+    "faultInst": {
+      "attributes": {
+        "dn": "topology/pod-1/node-103/local/svc-policyelem-id-0/uni/epp/rtd-[uni/tn-TK/out-OSPF/instP-EPG1]/nwissues/fault-F0467",
+        "code": "F0467",
+        "descr": "Configuration failed for uni/tn-TK/out-OSPF/instP-EPG1 due to Prefix Entry Already Used in Another EPG, debug message: ",
+        "delegated": "yes",
+        "changeSet": "configQual:prefix-entry-already-in-use, configSt:failed-to-apply, temporaryError:no"
+      }
+    }
+  },
+  {
+    "faultInst": {
+      "attributes": {
+        "dn": "topology/pod-1/node-103/local/svc-policyelem-id-0/uni/epp/rtd-[uni/tn-TK/out-EIGRP/instP-EPG1]/nwissues/fault-F0467",
+        "code": "F0467",
+        "descr": "Configuration failed for uni/tn-TK/out-EIGRP/instP-EPG1 due to Prefix Entry Already Used in Another EPG, debug message: ",
+        "delegated": "yes",
+        "changeSet": "configQual:prefix-entry-already-in-use, configSt:failed-to-apply, temporaryError:no"
+      }
+    }
+  },
+  {
+    "faultInst": {
+      "attributes": {
+        "dn": "topology/pod-1/node-104/local/svc-policyelem-id-0/uni/epp/rtd-[uni/tn-TK/out-BGP/instP-EPG2]/nwissues/fault-F0467",
+        "code": "F0467",
+        "descr": "Configuration failed for uni/tn-TK/out-BGP/instP-EPG2 due to Prefix Entry Already Used in Another EPG, debug message: ",
+        "delegated": "yes",
+        "changeSet": "configQual:prefix-entry-already-in-use, configSt:failed-to-apply, temporaryError:no"
+      }
+    }
+  },
+  {
+    "faultInst": {
+      "attributes": {
+        "dn": "topology/pod-1/node-104/local/svc-policyelem-id-0/uni/epp/rtd-[uni/tn-TK/out-OSPF/instP-EPG1]/nwissues/fault-F0467",
+        "code": "F0467",
+        "descr": "Configuration failed for uni/tn-TK/out-OSPF/instP-EPG1 due to Prefix Entry Already Used in Another EPG, debug message: ",
+        "delegated": "yes",
+        "changeSet": "configQual:prefix-entry-already-in-use, configSt:failed-to-apply, temporaryError:no"
+      }
+    }
+  },
+  {
+    "faultInst": {
+      "attributes": {
+        "dn": "topology/pod-1/node-104/local/svc-policyelem-id-0/uni/epp/rtd-[uni/tn-TK/out-EIGRP/instP-EPG1]/nwissues/fault-F0467",
+        "code": "F0467",
+        "descr": "Configuration failed for uni/tn-TK/out-EIGRP/instP-EPG1 due to Prefix Entry Already Used in Another EPG, debug message: ",
+        "delegated": "yes",
+        "changeSet": "configQual:prefix-entry-already-in-use, configSt:failed-to-apply, temporaryError:no"
       }
     }
   }

--- a/tests/prefix_already_in_use_check/fvCtx.json
+++ b/tests/prefix_already_in_use_check/fvCtx.json
@@ -2,330 +2,90 @@
   {
     "fvCtx": {
       "attributes": {
-        "annotation": "",
-        "bdEnforcedEnable": "no",
-        "childAction": "",
-        "descr": "",
         "dn": "uni/tn-mgmt/ctx-inb",
-        "extMngdBy": "",
-        "ipDataPlaneLearning": "enabled",
-        "knwMcastAct": "permit",
-        "lcOwn": "local",
-        "modTs": "2023-05-31T17:05:18.930-07:00",
-        "monPolDn": "uni/tn-common/monepg-default",
-        "name": "inb",
-        "nameAlias": "",
-        "ownerKey": "",
-        "ownerTag": "",
-        "pcEnfDir": "ingress",
-        "pcEnfDirUpdated": "yes",
-        "pcEnfPref": "enforced",
-        "pcTag": "32770",
-        "rn": "ctx-inb",
         "scope": "2097152",
-        "seg": "2097152",
-        "status": "",
-        "uid": "0",
-        "userdom": "all",
-        "vrfId": "0",
-        "vrfIndex": "0"
+        "seg": "2097152"
       }
     }
   },
   {
     "fvCtx": {
       "attributes": {
-        "annotation": "",
-        "bdEnforcedEnable": "no",
-        "childAction": "",
-        "descr": "",
         "dn": "uni/tn-TK/ctx-VRFA",
-        "extMngdBy": "",
-        "ipDataPlaneLearning": "enabled",
-        "knwMcastAct": "permit",
-        "lcOwn": "local",
-        "modTs": "2023-05-31T20:32:25.911-07:00",
-        "monPolDn": "uni/tn-common/monepg-default",
-        "name": "VRFA",
-        "nameAlias": "",
-        "ownerKey": "",
-        "ownerTag": "",
-        "pcEnfDir": "ingress",
-        "pcEnfDirUpdated": "yes",
-        "pcEnfPref": "enforced",
-        "pcTag": "32770",
-        "rn": "ctx-VRFA",
         "scope": "2457600",
-        "seg": "2457600",
-        "status": "",
-        "uid": "15374",
-        "userdom": ":all:",
-        "vrfId": "0",
-        "vrfIndex": "0"
+        "seg": "2457600"
       }
     }
   },
   {
     "fvCtx": {
       "attributes": {
-        "annotation": "",
-        "bdEnforcedEnable": "no",
-        "childAction": "",
-        "descr": "",
-        "dn": "uni/tn-common/ctx-copy",
-        "extMngdBy": "",
-        "ipDataPlaneLearning": "enabled",
-        "knwMcastAct": "permit",
-        "lcOwn": "local",
-        "modTs": "2023-05-31T17:05:19.821-07:00",
-        "monPolDn": "uni/tn-common/monepg-default",
-        "name": "copy",
-        "nameAlias": "",
-        "ownerKey": "",
-        "ownerTag": "",
-        "pcEnfDir": "ingress",
-        "pcEnfDirUpdated": "yes",
-        "pcEnfPref": "enforced",
-        "pcTag": "32770",
-        "rn": "ctx-copy",
-        "scope": "2359296",
-        "seg": "2359296",
-        "status": "",
-        "uid": "0",
-        "userdom": "all",
-        "vrfId": "0",
-        "vrfIndex": "0"
-      }
-    }
-  },
-  {
-    "fvCtx": {
-      "attributes": {
-        "annotation": "",
-        "bdEnforcedEnable": "no",
-        "childAction": "",
-        "descr": "",
-        "dn": "uni/tn-common/ctx-SPAN",
-        "extMngdBy": "",
-        "ipDataPlaneLearning": "enabled",
-        "knwMcastAct": "permit",
-        "lcOwn": "local",
-        "modTs": "2023-05-31T20:32:26.003-07:00",
-        "monPolDn": "uni/tn-common/monepg-default",
-        "name": "SPAN",
-        "nameAlias": "",
-        "ownerKey": "",
-        "ownerTag": "",
-        "pcEnfDir": "ingress",
-        "pcEnfDirUpdated": "yes",
-        "pcEnfPref": "enforced",
-        "pcTag": "16386",
-        "rn": "ctx-SPAN",
-        "scope": "2457601",
-        "seg": "2457601",
-        "status": "",
-        "uid": "15374",
-        "userdom": ":all:",
-        "vrfId": "0",
-        "vrfIndex": "0"
-      }
-    }
-  },
-  {
-    "fvCtx": {
-      "attributes": {
-        "annotation": "",
-        "bdEnforcedEnable": "no",
-        "childAction": "",
-        "descr": "",
-        "dn": "uni/tn-infra/ctx-overlay-1",
-        "extMngdBy": "",
-        "ipDataPlaneLearning": "enabled",
-        "knwMcastAct": "permit",
-        "lcOwn": "local",
-        "modTs": "2023-05-31T17:05:18.062-07:00",
-        "monPolDn": "uni/tn-common/monepg-default",
-        "name": "overlay-1",
-        "nameAlias": "",
-        "ownerKey": "",
-        "ownerTag": "",
-        "pcEnfDir": "ingress",
-        "pcEnfDirUpdated": "yes",
-        "pcEnfPref": "enforced",
-        "pcTag": "16386",
-        "rn": "ctx-overlay-1",
-        "scope": "16777199",
-        "seg": "16777199",
-        "status": "",
-        "uid": "0",
-        "userdom": "all",
-        "vrfId": "0",
-        "vrfIndex": "0"
-      }
-    }
-  },
-  {
-    "fvCtx": {
-      "attributes": {
-        "annotation": "",
-        "bdEnforcedEnable": "no",
-        "childAction": "",
-        "descr": "",
-        "dn": "uni/tn-infra/ctx-ave-ctrl",
-        "extMngdBy": "",
-        "ipDataPlaneLearning": "enabled",
-        "knwMcastAct": "permit",
-        "lcOwn": "local",
-        "modTs": "2023-05-31T17:05:19.703-07:00",
-        "monPolDn": "uni/tn-common/monepg-default",
-        "name": "ave-ctrl",
-        "nameAlias": "",
-        "ownerKey": "",
-        "ownerTag": "",
-        "pcEnfDir": "ingress",
-        "pcEnfDirUpdated": "yes",
-        "pcEnfPref": "enforced",
-        "pcTag": "32770",
-        "rn": "ctx-ave-ctrl",
-        "scope": "2654208",
-        "seg": "2654208",
-        "status": "",
-        "uid": "0",
-        "userdom": "all",
-        "vrfId": "0",
-        "vrfIndex": "0"
-      }
-    }
-  },
-  {
-    "fvCtx": {
-      "attributes": {
-        "annotation": "",
-        "bdEnforcedEnable": "no",
-        "childAction": "",
-        "descr": "",
-        "dn": "uni/tn-common/ctx-default",
-        "extMngdBy": "",
-        "ipDataPlaneLearning": "enabled",
-        "knwMcastAct": "permit",
-        "lcOwn": "local",
-        "modTs": "2023-05-31T17:05:19.821-07:00",
-        "monPolDn": "uni/tn-common/monepg-default",
-        "name": "default",
-        "nameAlias": "",
-        "ownerKey": "",
-        "ownerTag": "",
-        "pcEnfDir": "ingress",
-        "pcEnfDirUpdated": "yes",
-        "pcEnfPref": "enforced",
-        "pcTag": "32770",
-        "rn": "ctx-default",
-        "scope": "2621440",
-        "seg": "2621440",
-        "status": "",
-        "uid": "0",
-        "userdom": "all",
-        "vrfId": "0",
-        "vrfIndex": "0"
-      }
-    }
-  },
-  {
-    "fvCtx": {
-      "attributes": {
-        "annotation": "",
-        "bdEnforcedEnable": "no",
-        "childAction": "",
-        "descr": "",
-        "dn": "uni/tn-mgmt/ctx-oob",
-        "extMngdBy": "",
-        "ipDataPlaneLearning": "enabled",
-        "knwMcastAct": "permit",
-        "lcOwn": "local",
-        "modTs": "2023-05-31T17:05:18.930-07:00",
-        "monPolDn": "uni/tn-common/monepg-default",
-        "name": "oob",
-        "nameAlias": "",
-        "ownerKey": "",
-        "ownerTag": "",
-        "pcEnfDir": "ingress",
-        "pcEnfDirUpdated": "yes",
-        "pcEnfPref": "enforced",
-        "pcTag": "16386",
-        "rn": "ctx-oob",
-        "scope": "2981888",
-        "seg": "2981888",
-        "status": "",
-        "uid": "0",
-        "userdom": "all",
-        "vrfId": "0",
-        "vrfIndex": "0"
-      }
-    }
-  },
-  {
-    "fvCtx": {
-      "attributes": {
-        "annotation": "",
-        "bdEnforcedEnable": "no",
-        "childAction": "",
-        "descr": "",
         "dn": "uni/tn-TK/ctx-VRFB",
-        "extMngdBy": "",
-        "ipDataPlaneLearning": "enabled",
-        "knwMcastAct": "permit",
-        "lcOwn": "local",
-        "modTs": "2023-07-28T16:48:49.350-07:00",
-        "monPolDn": "uni/tn-common/monepg-default",
-        "name": "VRFB",
-        "nameAlias": "",
-        "ownerKey": "",
-        "ownerTag": "",
-        "pcEnfDir": "ingress",
-        "pcEnfDirUpdated": "yes",
-        "pcEnfPref": "enforced",
-        "pcTag": "32770",
-        "rn": "ctx-VRFB",
         "scope": "2260992",
-        "seg": "2260992",
-        "status": "",
-        "uid": "15374",
-        "userdom": ":all:",
-        "vrfId": "0",
-        "vrfIndex": "0"
+        "seg": "2260992"
       }
     }
   },
   {
     "fvCtx": {
       "attributes": {
-        "annotation": "",
-        "bdEnforcedEnable": "no",
-        "childAction": "",
-        "descr": "",
         "dn": "uni/tn-TK/ctx-VRFC",
-        "extMngdBy": "",
-        "ipDataPlaneLearning": "enabled",
-        "knwMcastAct": "permit",
-        "lcOwn": "local",
-        "modTs": "2023-07-28T16:49:00.206-07:00",
-        "monPolDn": "uni/tn-common/monepg-default",
-        "name": "VRFC",
-        "nameAlias": "",
-        "ownerKey": "",
-        "ownerTag": "",
-        "pcEnfDir": "ingress",
-        "pcEnfDirUpdated": "yes",
-        "pcEnfPref": "enforced",
-        "pcTag": "49153",
-        "rn": "ctx-VRFC",
         "scope": "2326528",
-        "seg": "2326528",
-        "status": "",
-        "uid": "15374",
-        "userdom": ":all:",
-        "vrfId": "0",
-        "vrfIndex": "0"
+        "seg": "2326528"
+      }
+    }
+  },
+  {
+    "fvCtx": {
+      "attributes": {
+        "dn": "uni/tn-common/ctx-copy",
+        "scope": "2359296",
+        "seg": "2359296"
+      }
+    }
+  },
+  {
+    "fvCtx": {
+      "attributes": {
+        "dn": "uni/tn-common/ctx-SPAN",
+        "scope": "2457601",
+        "seg": "2457601"
+      }
+    }
+  },
+  {
+    "fvCtx": {
+      "attributes": {
+        "dn": "uni/tn-infra/ctx-overlay-1",
+        "scope": "16777199",
+        "seg": "16777199"
+      }
+    }
+  },
+  {
+    "fvCtx": {
+      "attributes": {
+        "dn": "uni/tn-infra/ctx-ave-ctrl",
+        "scope": "2654208",
+        "seg": "2654208"
+      }
+    }
+  },
+  {
+    "fvCtx": {
+      "attributes": {
+        "dn": "uni/tn-common/ctx-default",
+        "scope": "2621440",
+        "seg": "2621440"
+      }
+    }
+  },
+  {
+    "fvCtx": {
+      "attributes": {
+        "dn": "uni/tn-mgmt/ctx-oob",
+        "scope": "2981888",
+        "seg": "2981888"
       }
     }
   }

--- a/tests/prefix_already_in_use_check/l3extRsEctx.json
+++ b/tests/prefix_already_in_use_check/l3extRsEctx.json
@@ -1,0 +1,50 @@
+[
+  {
+    "l3extRsEctx": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-BGP/rsectx",
+        "tDn": "uni/tn-TK/ctx-VRFA"
+      }
+    }
+  },
+  {
+    "l3extRsEctx": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-OSPF/rsectx",
+        "tDn": "uni/tn-TK/ctx-VRFA"
+      }
+    }
+  },
+  {
+    "l3extRsEctx": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-EIGRP/rsectx",
+        "tDn": "uni/tn-TK/ctx-VRFA"
+      }
+    }
+  },
+  {
+    "l3extRsEctx": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-BGP2/rsectx",
+        "tDn": "uni/tn-TK/ctx-VRFB"
+      }
+    }
+  },
+  {
+    "l3extRsEctx": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-OSPF2/rsectx",
+        "tDn": "uni/tn-TK/ctx-VRFB"
+      }
+    }
+  },
+  {
+    "l3extRsEctx": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-EIGRP2/rsectx",
+        "tDn": "uni/tn-TK/ctx-VRFB"
+      }
+    }
+  }
+]

--- a/tests/prefix_already_in_use_check/l3extSubnet_no_overlap.json
+++ b/tests/prefix_already_in_use_check/l3extSubnet_no_overlap.json
@@ -1,0 +1,74 @@
+[
+  {
+    "l3extSubnet": {
+      "attributes": {
+        "dn": "uni/tn-infra/fabricExtConnP-1/fabricExtRoutingP-IPN/extsubnet-[20.200.0.1/30]",
+        "ip": "20.200.0.1/30",
+        "scope": "import-security"
+      }
+    }
+  },
+  {
+    "l3extSubnet": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-BGP/instP-EPG1/extsubnet-[10.0.0.0/8]",
+        "ip": "10.0.0.0/8",
+        "scope": "import-security,shared-security"
+      }
+    }
+  },
+  {
+    "l3extSubnet": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-BGP/instP-EPG2/extsubnet-[11.0.0.0/8]",
+        "ip": "11.0.0.0/8",
+        "scope": "import-security,shared-security"
+      }
+    }
+  },
+  {
+    "l3extSubnet": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-OSPF/instP-EPG1/extsubnet-[12.0.0.0/8]",
+        "ip": "12.0.0.0/8",
+        "scope": "import-security"
+      }
+    }
+  },
+  {
+    "l3extSubnet": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-EIGRP/instP-EPG1/extsubnet-[13.0.0.0/8]",
+        "ip": "13.0.0.0/8",
+        "scope": "import-security"
+      }
+    }
+  },
+  {
+    "l3extSubnet": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-BGP2/instP-EPG1/extsubnet-[10.0.0.0/8]",
+        "ip": "10.0.0.0/8",
+        "scope": "import-security,shared-security"
+      }
+    }
+  },
+  {
+    "l3extSubnet": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-OSPF2/instP-EPG1/extsubnet-[20.0.0.0/8]",
+        "ip": "20.0.0.0/8",
+        "scope": "import-security"
+      }
+    }
+  },
+  {
+    "l3extSubnet": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-EIGRP2/instP-EPG1/extsubnet-[30.0.0.0/8]",
+        "ip": "30.0.0.0/8",
+        "scope": "import-security"
+      }
+    }
+  }
+]

--- a/tests/prefix_already_in_use_check/l3extSubnet_overlap.json
+++ b/tests/prefix_already_in_use_check/l3extSubnet_overlap.json
@@ -1,0 +1,74 @@
+[
+  {
+    "l3extSubnet": {
+      "attributes": {
+        "dn": "uni/tn-infra/fabricExtConnP-1/fabricExtRoutingP-IPN/extsubnet-[20.200.0.1/30]",
+        "ip": "20.200.0.1/30",
+        "scope": "import-security"
+      }
+    }
+  },
+  {
+    "l3extSubnet": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-BGP/instP-EPG1/extsubnet-[10.0.0.0/8]",
+        "ip": "10.0.0.0/8",
+        "scope": "import-security,shared-security"
+      }
+    }
+  },
+  {
+    "l3extSubnet": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-BGP/instP-EPG2/extsubnet-[10.0.0.0/8]",
+        "ip": "10.0.0.0/8",
+        "scope": "import-security,shared-security"
+      }
+    }
+  },
+  {
+    "l3extSubnet": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-OSPF/instP-EPG1/extsubnet-[10.0.0.0/8]",
+        "ip": "10.0.0.0/8",
+        "scope": "import-security"
+      }
+    }
+  },
+  {
+    "l3extSubnet": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-EIGRP/instP-EPG1/extsubnet-[10.0.0.0/8]",
+        "ip": "10.0.0.0/8",
+        "scope": "import-security"
+      }
+    }
+  },
+  {
+    "l3extSubnet": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-BGP2/instP-EPG1/extsubnet-[10.0.0.0/8]",
+        "ip": "10.0.0.0/8",
+        "scope": "import-security,shared-security"
+      }
+    }
+  },
+  {
+    "l3extSubnet": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-OSPF2/instP-EPG1/extsubnet-[10.0.0.0/8]",
+        "ip": "20.0.0.0/8",
+        "scope": "import-security"
+      }
+    }
+  },
+  {
+    "l3extSubnet": {
+      "attributes": {
+        "dn": "uni/tn-TK/out-EIGRP2/instP-EPG1/extsubnet-[10.0.0.0/8]",
+        "ip": "30.0.0.0/8",
+        "scope": "import-security"
+      }
+    }
+  }
+]

--- a/tests/prefix_already_in_use_check/test_prefix_already_in_use_check.py
+++ b/tests/prefix_already_in_use_check/test_prefix_already_in_use_check.py
@@ -13,6 +13,8 @@ dir = os.path.dirname(os.path.abspath(__file__))
 # icurl queries
 faultInst = 'faultInst.json?query-target-filter=and(wcard(faultInst.changeSet,"prefix-entry-already-in-use"),wcard(faultInst.dn,"uni/epp/rtd"))'
 fvCtx = "fvCtx.json"
+l3extRsEctx = "l3extRsEctx.json"
+l3extSubnet = "l3extSubnet.json"
 
 
 @pytest.mark.parametrize(
@@ -25,6 +27,8 @@ fvCtx = "fvCtx.json"
                     dir, "faultInst_F0467_prefix-entry-already-in-use_old.json"
                 ),
                 fvCtx: read_data(dir, "fvCtx.json"),
+                l3extRsEctx: read_data(dir, "l3extRsEctx.json"),
+                l3extSubnet: read_data(dir, "l3extSubnet_overlap.json"),
             },
             script.FAIL_O,
         ),
@@ -35,6 +39,8 @@ fvCtx = "fvCtx.json"
                     dir, "faultInst_F0467_prefix-entry-already-in-use_new.json"
                 ),
                 fvCtx: read_data(dir, "fvCtx.json"),
+                l3extRsEctx: read_data(dir, "l3extRsEctx.json"),
+                l3extSubnet: read_data(dir, "l3extSubnet_overlap.json"),
             },
             script.FAIL_O,
         ),
@@ -42,6 +48,8 @@ fvCtx = "fvCtx.json"
             {
                 faultInst: [],
                 fvCtx: read_data(dir, "fvCtx.json"),
+                l3extRsEctx: read_data(dir, "l3extRsEctx.json"),
+                l3extSubnet: read_data(dir, "l3extSubnet_no_overlap.json"),
             },
             script.PASS,
         ),


### PR DESCRIPTION
fix #196 

* When the fault doesn't include the VRF and prefix that is overlapping as the version is too old.
```
[Check  1/1] L3Out Subnets (F0467 prefix-entry-already-in-use)...                                                 FAIL - OUTAGE WARNING!!
  Fault  Failed L3Out EPG
  -----  ----------------
  F0467  uni/tn-TK/out-BGP/instP-EPG2
  F0467  uni/tn-TK/out-EIGRP/instP-EPG1
  F0467  uni/tn-TK/out-OSPF/instP-EPG1

  Recommended Action: Resolve the conflict by removing the overlapping prefix from the faulted L3Out EPG.
```

* When the fault does include the VRF and prefix that is overlapping, the check was enhanced to check other faults and L3Out EPGs without a fault to show which L3Out EPGs are configured with the said prefix.
```
[Check  1/1] L3Out Subnets (F0467 prefix-entry-already-in-use)...                                                 FAIL - OUTAGE WARNING!!
  VRF Name            Prefix      L3Out EPGs without F0467      L3Out EPGs with F0467
  --------            ------      ------------------------      ---------------------
  uni/tn-TK/ctx-VRFA  10.0.0.0/8  uni/tn-TK/out-BGP/instP-EPG1  uni/tn-TK/out-BGP/instP-EPG2,uni/tn-TK/out-EIGRP/instP-EPG1,uni/tn-TK/out-OSPF/instP-EPG1

  Recommended Action: Resolve the conflict by removing the overlapping prefix from the faulted L3Out EPG.
```

* Pass case
```
[Check  1/1] L3Out Subnets (F0467 prefix-entry-already-in-use)...                                                                    PASS
```

<details>
<summary>pytest outputs:</summary>

```
[Check  1/1] L3Out Subnets (F0467 prefix-entry-already-in-use)...                                                 FAIL - OUTAGE WARNING!!
  Fault  Failed L3Out EPG
  -----  ----------------
  F0467  uni/tn-TK/out-BGP/instP-EPG2
  F0467  uni/tn-TK/out-EIGRP/instP-EPG1
  F0467  uni/tn-TK/out-OSPF/instP-EPG1

  Recommended Action: Resolve the conflict by removing the overlapping prefix from the faulted L3Out EPG.


[Check  1/1] L3Out Subnets (F0467 prefix-entry-already-in-use)...                                                 FAIL - OUTAGE WARNING!!
  VRF Name            Prefix      L3Out EPGs without F0467      L3Out EPGs with F0467
  --------            ------      ------------------------      ---------------------
  uni/tn-TK/ctx-VRFA  10.0.0.0/8  uni/tn-TK/out-BGP/instP-EPG1  uni/tn-TK/out-BGP/instP-EPG2,uni/tn-TK/out-EIGRP/instP-EPG1,uni/tn-TK/out-OSPF/instP-EPG1

  Recommended Action: Resolve the conflict by removing the overlapping prefix from the faulted L3Out EPG.


[Check  1/1] L3Out Subnets (F0467 prefix-entry-already-in-use)...                                                                    PASS
```

</details>

Integration tests passed.