### PR TITLE
Add Global AES Encryption check

### DIFF
--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -123,6 +123,7 @@ Items                                         | Faults         | This Script    
 [Out-of-Service Ports check][c18]                     | :white_check_mark: | :no_entry_sign:           | :no_entry_sign:  
 [TEP-to-TEP atomic counters Scalability Check][c19]   | :white_check_mark: | :no_entry_sign:           | :no_entry_sign:
 [HTTPS Request Throttle Rate][c20]                    | :white_check_mark: | :no_entry_sign:           | :no_entry_sign:
+[Global AES Encryption][c21]                          | :white_check_mark: | :white_check_mark: 6.1(2) | :no_entry_sign:
 
 [c1]: #vpc-paired-leaf-switches
 [c2]: #overlapping-vlan-pool
@@ -144,6 +145,7 @@ Items                                         | Faults         | This Script    
 [c18]: #out-of-service-ports-check
 [c19]: #tep-to-tep-atomic-counters-scalability-check
 [c20]: #https-request-throttle-rate
+[c21]: #global-aes-encryption
 
 ### Defect Condition Checks
 
@@ -2009,6 +2011,20 @@ This script checks the configuration in all Management Access Policies to alert 
     Also note that **HTTPS Request Throttle** in this check is referring to the global throttling as opposed to the new feature **Custom Throttle Group** that was introduced in 6.1(2).
 
 
+### Global AES Encryption
+
+**Global AES Encryption** enables Cisco APICs to encrypt passwords and include them in the configuration export (backup). See [ACI Best Practices Quick Summary][49] for details about the feature itself.
+
+In terms of upgrade, taking a configuration backup with **Global AES Encryption** enabled before your upgrade is highly recommended so that you or Cisco TAC can restore your fabric even if something unexpected may occur during your upgrade.
+
+Although enabling **Global AES Encryption** has been a best practice, it has become mandatory to upgrade to ACI version 6.1(2) or later. If you proceed with your APIC upgrade to 6.1(2) or newer version while **Global AES Encryption** is disabled, the upgrade will immediately fail.
+
+When **Global AES Encryption** is not enabled, this script alerts users in two different ways depending on the target version.
+
+* When it is not enabled and the target version is 6.1(2) or later, this check is flagged as `UPGRADE FAILURE`.
+* When it is not enabled and the target version is older than 6.1(2), this check is flagged as `MANUAL CHECK REQUIRED` to encourage users to follow the best practice to enable it (and take a configuration back again before the upgrade).
+
+
 ## Defect Check Details
 
 ### EP Announce Compatibility
@@ -2391,3 +2407,4 @@ If this alert is flagged then plan for an interim upgrade hop to a fixed version
 [46]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwi66348
 [47]: https://www.cisco.com/c/en/us/td/docs/dcn/whitepapers/cisco-aci-best-practices-quick-summary.html#HTTPSRequestThrottle
 [48]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwa44220
+[49]: https://www.cisco.com/c/en/us/td/docs/dcn/whitepapers/cisco-aci-best-practices-quick-summary.html#GlobalAESEncryption

--- a/tests/aes_encryption_check/exportcryptkey.json
+++ b/tests/aes_encryption_check/exportcryptkey.json
@@ -1,0 +1,16 @@
+[
+  {
+    "pkiExportEncryptionKey": {
+      "attributes": {
+        "clearEncryptionKey": "no",
+        "cryptedPassphrase": "$6$YDIPTUFFZQAU$kVcq9zRiaFzvYbNSi6y5UfLMfhb5kG5dGs1EcKOpJ1MgkbEpbSW5yWwe.tR.0Ma3WO2xJKrpc6a6zAICMk.Ot1",
+        "dn": "uni/exportcryptkey",
+        "issues": "",
+        "keyConfigured": "yes",
+        "passphraseKeyDerivationVersion": "v1",
+        "strongEncryptionEnabled": "yes",
+        "timeGenerated": "2025-03-19T11:36:00.433-07:00"
+      }
+    }
+  }
+]

--- a/tests/aes_encryption_check/exportcryptkey_disabled.json
+++ b/tests/aes_encryption_check/exportcryptkey_disabled.json
@@ -1,0 +1,16 @@
+[
+  {
+    "pkiExportEncryptionKey": {
+      "attributes": {
+        "clearEncryptionKey": "no",
+        "cryptedPassphrase": "",
+        "dn": "uni/exportcryptkey",
+        "issues": "encryption-disabled",
+        "keyConfigured": "no",
+        "passphraseKeyDerivationVersion": "v1",
+        "strongEncryptionEnabled": "no",
+        "timeGenerated": "2025-03-19T11:36:00.433-07:00"
+      }
+    }
+  }
+]

--- a/tests/aes_encryption_check/test_aes_encryption_check.py
+++ b/tests/aes_encryption_check/test_aes_encryption_check.py
@@ -1,0 +1,60 @@
+import os
+import pytest
+import logging
+import importlib
+from helpers.utils import read_data
+
+script = importlib.import_module("aci-preupgrade-validation-script")
+
+log = logging.getLogger(__name__)
+dir = os.path.dirname(os.path.abspath(__file__))
+
+
+# icurl queries
+exportcryptkey = "uni/exportcryptkey.json"
+
+
+@pytest.mark.parametrize(
+    "icurl_outputs, tversion, expected_result",
+    [
+        # AES enabled (tversion > 6.1.2a)
+        (
+            {exportcryptkey: read_data(dir, "exportcryptkey.json")},
+            "6.1(3b)",
+            script.PASS,
+        ),
+        # AES enabled (tversion < 6.1.2a)
+        (
+            {exportcryptkey: read_data(dir, "exportcryptkey.json")},
+            "5.2(8g)",
+            script.PASS,
+        ),
+        # AES disabled (tversion > 6.1.2a)
+        (
+            {exportcryptkey: read_data(dir, "exportcryptkey_disabled.json")},
+            "6.1(3b)",
+            script.FAIL_UF,
+        ),
+        # AES disabled (tversion < 6.1.2a)
+        (
+            {exportcryptkey: read_data(dir, "exportcryptkey_disabled.json")},
+            "5.2(8g)",
+            script.MANUAL,
+        ),
+        # AES MO not found (tversion > 6.1.2a)
+        (
+            {exportcryptkey: []},
+            "6.1(3b)",
+            script.FAIL_UF,
+        ),
+        # AES MO not found (tversion < 6.1.2a)
+        (
+            {exportcryptkey: []},
+            "5.2(8g)",
+            script.MANUAL,
+        ),
+    ],
+)
+def test_logic(mock_icurl, tversion, expected_result):
+    result = script.aes_encryption_check(1, 1, script.AciVersion(tversion))
+    assert result == expected_result


### PR DESCRIPTION
fix #185 

Considering that Global AES Encryption is a best practice we recommend on any version, this check warns users about it when it's not enabled in two different ways depending on the target version.

* When it is not enabled and the target version is 6.1(2) or later, this check is flagged as UPGRADE FAILURE.
* When it is not enabled and the target version is older than 6.1(2), this check is flagged as MANUAL CHECK REQUIRED to encourage users to follow the best practice to enable it (and take a configuration back again before the upgrade).



pytest outputs:
```
[Check  1/1] Global AES Encryption...                                                                                                PASS
[Check  1/1] Global AES Encryption...                                                                                                PASS
[Check  1/1] Global AES Encryption...                                                                            FAIL - UPGRADE FAILURE!!
  Target Version  Global AES Encryption  Impact
  --------------  ---------------------  ------
  6.1(3b)         Disabled               Upgrade Failure

  Recommended Action:
        Enable Global AES Encryption before upgrading your APIC (and take a configuration backup).
        Global AES Encryption ensures that all configurations are included in the backup securely.
        Upgrade to 6.1(2) or later will fail when it is not enabled.
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#global-aes-encryption


[Check  1/1] Global AES Encryption...                                                                               MANUAL CHECK REQUIRED
  Target Version  Global AES Encryption  Impact
  --------------  ---------------------  ------
  5.2(8g)         Disabled               Your config backup may not contain all data

  Recommended Action:
        Enable Global AES Encryption before upgrading your APIC (and take a configuration backup).
        Global AES Encryption ensures that all configurations are included in the backup securely.
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#global-aes-encryption


[Check  1/1] Global AES Encryption...                                                                            FAIL - UPGRADE FAILURE!!
  Target Version  Global AES Encryption  Impact
  --------------  ---------------------  ------
  6.1(3b)         Object Not Found       Upgrade Failure

  Recommended Action:
        Enable Global AES Encryption before upgrading your APIC (and take a configuration backup).
        Global AES Encryption ensures that all configurations are included in the backup securely.
        Upgrade to 6.1(2) or later will fail when it is not enabled.
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#global-aes-encryption


[Check  1/1] Global AES Encryption...                                                                               MANUAL CHECK REQUIRED
  Target Version  Global AES Encryption  Impact
  --------------  ---------------------  ------
  5.2(8g)         Object Not Found       Your config backup may not contain all data

  Recommended Action:
        Enable Global AES Encryption before upgrading your APIC (and take a configuration backup).
        Global AES Encryption ensures that all configurations are included in the backup securely.
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#global-aes-encryption
```

Integration tests also passed.