### PR TITLE
Fix regex warning of missing r prefix

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -121,7 +121,7 @@ class Connection(object):
         self.protocol = "ssh"
         self.port = None
         self.timeout = 30
-        self.prompt = "#\s.*$" #"[^#]#[ ]*(.*)*[ ]*$"
+        self.prompt = r"#\s.*$"
         self.verify = False
         self.searchwindowsize = 256
         self.force_wait = 0


### PR DESCRIPTION
On a newer version of APIC, a python warning shown below is displayed. The same is shown in pytest with python3.

This PR is fixing this warning simply by adding the `r` prefix to the regex string.

```
admin@apic1:techsupport> python aci-preupgrade-validation-script.py
/data/techsupport/aci-preupgrade-validation-script.py:124: SyntaxWarning: invalid escape sequence '\s'    <---
  self.prompt = "#\s.*$" #"[^#]#[ ]*(.*)*[ ]*$"                                                 <----
    ==== 2025-04-03T00-32-07-0700, Script Version v2.4.0  ====

!!!! Check https://github.com/datacenter/ACI-Pre-Upgrade-Validation-Script for Latest Release !!!!

To use a non-default Login Domain, enter apic#DOMAIN\\USERNAME
Enter username for APIC login          : admin
Enter password for corresponding User  :

   ---- omit ----
```

After the fix:
```
admin@apic1:techsupport> python aci-preupgrade-validation-script.py
    ==== 2025-04-03T00-48-28-0700, Script Version v2.4.0  ====

!!!! Check https://github.com/datacenter/ACI-Pre-Upgrade-Validation-Script for Latest Release !!!!

To use a non-default Login Domain, enter apic#DOMAIN\\USERNAME
Enter username for APIC login          : admin
Enter password for corresponding User  :
```

