### PR TITLE
Add SG BD forceful routing check

### DIFF
--- a/tests/service_bd_forceful_routing_check/fvRtEPpInfoToBD.json
+++ b/tests/service_bd_forceful_routing_check/fvRtEPpInfoToBD.json
@@ -1,0 +1,54 @@
+[
+  {
+    "fvRtEPpInfoToBD": {
+      "attributes": {
+        "childAction": "",
+        "dn": "uni/tn-TK/BD-BD1/rtvnsEPpInfoToBD-[uni/tn-TK/LDevInst-[uni/tn-TK/lDevVip-N9K]-ctx-VRFA/G-N9KctxVRFA-N-BD1-C-one-arm]",
+        "lcOwn": "local",
+        "modTs": "2025-04-03T15:48:27.052-07:00",
+        "status": "",
+        "tCl": "vnsEPpInfo",
+        "tDn": "uni/tn-TK/LDevInst-[uni/tn-TK/lDevVip-N9K]-ctx-VRFA/G-N9KctxVRFA-N-BD1-C-one-arm"
+      }
+    }
+  },
+  {
+    "fvRtEPpInfoToBD": {
+      "attributes": {
+        "childAction": "",
+        "dn": "uni/tn-TK/BD-BD_PBR/rtvnsEPpInfoToBD-[uni/tn-TK/LDevInst-[uni/tn-TK/lDevVip-ASAv]-ctx-VRFA/G-ASAvctxVRFA-N-BD_PBR-C-one-arm]",
+        "lcOwn": "local",
+        "modTs": "2025-04-04T23:12:34.647-07:00",
+        "status": "",
+        "tCl": "vnsEPpInfo",
+        "tDn": "uni/tn-TK/LDevInst-[uni/tn-TK/lDevVip-ASAv]-ctx-VRFA/G-ASAvctxVRFA-N-BD_PBR-C-one-arm"
+      }
+    }
+  },
+  {
+    "fvRtEPpInfoToBD": {
+      "attributes": {
+        "childAction": "",
+        "dn": "uni/tn-TK/BD-BD_PBR/rtvnsEPpInfoToBD-[uni/tn-TK/LDevInst-[uni/tn-TK/lDevVip-LB]-ctx-VRFA/G-LBctxVRFA-N-BD_PBR-C-one-arm]",
+        "lcOwn": "local",
+        "modTs": "2025-04-04T23:26:16.948-07:00",
+        "status": "",
+        "tCl": "vnsEPpInfo",
+        "tDn": "uni/tn-TK/LDevInst-[uni/tn-TK/lDevVip-LB]-ctx-VRFA/G-LBctxVRFA-N-BD_PBR-C-one-arm"
+      }
+    }
+  },
+  {
+    "fvRtEPpInfoToBD": {
+      "attributes": {
+        "childAction": "",
+        "dn": "uni/tn-TK/BD-BD2/rtvnsEPpInfoToBD-[uni/tn-TK/LDevInst-[uni/tn-common/lDevVip-CMN_LB]-ctx-VRFA/G-CMN_LBctxVRFA-N-BD2-C-cluster-if1]",
+        "lcOwn": "local",
+        "modTs": "2025-04-05T00:08:15.075-07:00",
+        "status": "",
+        "tCl": "vnsEPpInfo",
+        "tDn": "uni/tn-TK/LDevInst-[uni/tn-common/lDevVip-CMN_LB]-ctx-VRFA/G-CMN_LBctxVRFA-N-BD2-C-cluster-if1"
+      }
+    }
+  }
+]

--- a/tests/service_bd_forceful_routing_check/test_service_bd_forceful_routing_check.py
+++ b/tests/service_bd_forceful_routing_check/test_service_bd_forceful_routing_check.py
@@ -1,0 +1,61 @@
+import os
+import pytest
+import logging
+import importlib
+from helpers.utils import read_data
+
+script = importlib.import_module("aci-preupgrade-validation-script")
+
+log = logging.getLogger(__name__)
+dir = os.path.dirname(os.path.abspath(__file__))
+
+
+# icurl queries
+fvRtEPpInfoToBD = "fvRtEPpInfoToBD.json"
+
+
+@pytest.mark.parametrize(
+    "icurl_outputs, cversion, tversion, expected_result",
+    [
+        # tversion missing
+        (
+            {fvRtEPpInfoToBD: read_data(dir, "fvRtEPpInfoToBD.json")},
+            "5.2(8h)",
+            None,
+            script.MANUAL
+        ),
+        # Version not affected (both new)
+        (
+            {fvRtEPpInfoToBD: read_data(dir, "fvRtEPpInfoToBD.json")},
+            "6.0(2h)",
+            "6.1(3b)",
+            script.NA,
+        ),
+        # Version not affected (both old)
+        (
+            {fvRtEPpInfoToBD: read_data(dir, "fvRtEPpInfoToBD.json")},
+            "4.2(7s)",
+            "6.0(1h)",
+            script.NA,
+        ),
+        # Version affected with L4L7 service graph BD
+        (
+            {fvRtEPpInfoToBD: read_data(dir, "fvRtEPpInfoToBD.json")},
+            "5.2(8h)",
+            "6.0(2h)",
+            script.MANUAL
+        ),
+        # Version affected without L4L7 service graph BD
+        (
+            {fvRtEPpInfoToBD: []},
+            "5.2(8h)",
+            "6.0(2h)",
+            script.PASS,
+        ),
+    ],
+)
+def test_logic(mock_icurl, cversion, tversion, expected_result):
+    cver = script.AciVersion(cversion)
+    tver = script.AciVersion(tversion) if tversion else None
+    result = script.service_bd_forceful_routing_check(1, 1, cver, tver)
+    assert result == expected_result


### PR DESCRIPTION
fix #183 

* Checks `fvRtEPpInfoToBD`, which is under a BD, to get all BDs with a service graph (regardless of PBR or not)

I did not go with `vnsRsLIfCtxToBD` which is "Device Selection Policy > Logical Device Context > Logical Interface" because of two reasons below.
* This represents a cluster interface which may contain multiple physical interfaces from different service (concrete) devices.
* This does not have the service graph device name.

pytest output:
```
[Check  1/1] Service Graph BD Forceful Routing... Target version not supplied. Skipping.                            MANUAL CHECK REQUIRED
[Check  1/1] Service Graph BD Forceful Routing...                                                                                     N/A
[Check  1/1] Service Graph BD Forceful Routing...                                                                                     N/A
[Check  1/1] Service Graph BD Forceful Routing...                                                                   MANUAL CHECK REQUIRED
  Bridge Domain (Tenant:BD)  Service Graph Device (Tenant:Device)
  -------------------------  ------------------------------------
  TK:BD1                     TK:N9K
  TK:BD2                     common:CMN_LB
  TK:BD_PBR                  TK:ASAv
  TK:BD_PBR                  TK:LB

  Recommended Action:
        Confirm that within these BDs there is no bridging traffic with the destination IP that doesn't belong to them.
        Please check the reference document for details.
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#service-graph-bd-forceful-routing


[Check  1/1] Service Graph BD Forceful Routing...                                                                                    PASS
```

Integration tests also passed.