### PR TITLE
Fix `Connection` class byte string handling in py3

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -2596,7 +2596,6 @@ def lldp_with_infra_vlan_mismatch_check(index, total_checks, **kwargs):
 
 
 def apic_version_md5_check(index, total_checks, tversion, username, password, **kwargs):
-    # TODO: 'unexpected output when checking md5sum file' may be cuasing stdout print issue
     title = 'APIC Target version image and MD5 hash'
     result = FAIL_UF
     msg = ''

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -360,7 +360,7 @@ class Connection(object):
             time.sleep(self.force_wait)
 
         result = self.__expect(matches, timeout)
-        self.output = "%s%s" % (self.child.before, self.child.after)
+        self.output = "%s%s" % (self.child.before.decode("utf-8"), self.child.after.decode("utf-8"))
         if result == "eof" or result == "timeout":
             logging.warning("unexpected %s occurred" % result)
         return result

--- a/tests/apic_version_md5_check/test_apic_version_md5_check.py
+++ b/tests/apic_version_md5_check/test_apic_version_md5_check.py
@@ -73,7 +73,7 @@ f2-apic1#
             True,
             [],
             "6.0(5h)",
-            script.FAIL_UF,
+            script.ERROR,
         ),
         # Exception failure at the ls command
         (
@@ -93,7 +93,7 @@ f2-apic1#
                 for apic_ip in apic_ips
             },
             "6.0(5h)",
-            script.FAIL_UF,
+            script.ERROR,
         ),
         # No such file output from the ls command
         (
@@ -138,7 +138,7 @@ f2-apic1#
                 for apic_ip in apic_ips
             },
             "6.0(5h)",
-            script.FAIL_UF,
+            script.ERROR,
         ),
         # No such file output from the cat command
         (
@@ -188,7 +188,7 @@ f2-apic1#
                 for apic_ip in apic_ips
             },
             "6.0(5h)",
-            script.FAIL_UF,
+            script.ERROR,
         ),
         # Failure because md5sum on each APIC do not match
         (

--- a/tests/observer_db_size_check/test_observer_db_size_check.py
+++ b/tests/observer_db_size_check/test_observer_db_size_check.py
@@ -48,7 +48,7 @@ apic1#
             {topSystem_api: read_data(dir, "topSystem.json")},
             True,
             [],
-            script.FAIL_UF,
+            script.ERROR,
         ),
         # Simulatated exception at `ls` command
         (
@@ -64,7 +64,7 @@ apic1#
                 ]
                 for apic_ip in apic_ips
             },
-            script.FAIL_UF,
+            script.ERROR,
         ),
         # dbstats dir not found/not accessible
         (
@@ -80,7 +80,7 @@ apic1#
                 ]
                 for apic_ip in apic_ips
             },
-            script.FAIL_UF,
+            script.ERROR,
         ),
         # dbstats dir found, all DBs under 1G
         (


### PR DESCRIPTION
## Summary
* Decode the SSH output as "utf-8" in class `Connection`
* Change the result to `ERROR` from `FAIL_UF` when the SSH connection check on at least one APIC resulted in `ERROR`

## Details
On newer APIC versions with py3, checks that use class `Connection` (i.e. SSH to each APIC instead of API queries) are either failing or missing the condition silently.

### Example 1) `apic_version_md5_check()`

```
  APIC        Firmware  md5sum  Failure                                      Recommended Action
  ----        --------  ------  -------                                      ------------------
  S2-APIC-1   6.1(3f)   -       unexpected output when checking md5sum file  Delete the firmware from APIC and re-download
  S2-APIC-2   6.1(3f)   -       unexpected output when checking md5sum file  Delete the firmware from APIC and re-download
  S2-APIC-3   6.1(3f)   -       unexpected output when checking md5sum file  Delete the firmware from APIC and re-download
```

These errors are because the output from SSH via `Connection` class is a byte string which is of class `bytes` in py3 while it's of class `str` in py2.

The string formatting used by the `Connection` class (`"%s%s" % (self.child.before, self.child.after)`) works in a different way in py2 and py3 as shown below. It works with py2 while it doesn't with py3.

```py
> python
Python 3.8.20 (default, Sep  7 2024, 18:35:08)
[GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> "%s%s" % (b'123\n', b'456\n')
"b'123\\n'b'456\\n'"
>>>                                                                                                                                  

> python
Python 2.7.18 (default, Jul  1 2022, 10:30:50)
[GCC 11.2.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> "%s%s" % (b'123\n', b'456\n')
'123\n456\n'
>>>
```

This was fixed by applying `.decode("utf-8")` when the `Connection` class gets the CLI output.

Also, these errors were not caught during the internal integration tests which look out for any `ERROR` in the final result because this (and other connection checks) resulted in `FAIL_UF` when there were `ERROR` in one or more of the SSH output from APICs.


### Example 2) `observer_db_size_check()`

This check always resulted in `PASS` on newer APIC versions with py3 because of the byte string handling mentioned above.

The CLI output on py3
```
b"\x1b[?1h\x1b=\x1b[?2004hl\x08ls -lh /data2/dbstats | awk '{print $5, $9}'\x1b[?1l\x1b>\x1b[?2004l\r\r\n \r\n50M observer_11.db\r\n20M observer_14.db\r\n56M observer_17.db\r\n20M observer_2.db\r\n20M observer_20.db\r\n20M observer_23.db\r\n30M observer_255.db\r\n44M observer_26.db\r\n20M observer_29.db\r\n40M observer_32.db\r\n43M observer_5.db\r\n42M observer_8.db\r\n20M observer_template.db\r\n\x1b[1m\x1b[7m%\x1b[27m\x1b[1m\x1b[0m                                                                               \r \r\r\x1b[0m\x1b[27m\x1b[24m\x1b[JS2-APIC-2"b'# \x1b[K'
```

The CLI output on py2
```
ls -lh /data2/dbstats | awk '{print $5, $9}'

16M observer_1.db
15M observer_10.db
40M observer_11.db
...
```

Because of this `re.match` never matched to find a large DB file.