### PR TITLE
Puv pytest

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -55,23 +55,24 @@ dom_regex = r"uni/(?:vmmp-[^/]+/)?(?P<type>phys|l2dom|l3dom|dom)-(?P<dom>[^/]+)"
 
 tz = time.strftime('%z')
 ts = datetime.now().strftime('%Y-%m-%dT%H-%M-%S')
-LIVE_RESULTS_DIR = "cx-preupgrade-validation-results"
-DIR = 'preupgrade_validator_logs/'
 BUNDLE_NAME = 'preupgrade_validator_%s%s.tgz' % (ts, tz)
+DIR = 'preupgrade_validator_logs/'
+JSON_DIR = DIR + 'json_results/'
+META_FILE = DIR + 'meta.json'
 RESULT_FILE = DIR + 'preupgrade_validator_%s%s.txt' % (ts, tz)
-JSON_FILE = DIR + 'preupgrade_validator_%s%s.json' % (ts, tz)
 SUMMARY_FILE = DIR + 'summary.json'
 LOG_FILE = DIR + 'preupgrade_validator_debug.log'
 fmt = '[%(asctime)s.%(msecs)03d{} %(levelname)-8s %(funcName)20s:%(lineno)-4d] %(message)s'.format(tz)
 if os.path.isdir(DIR):
     shutil.rmtree(DIR)
 os.mkdir(DIR)
+os.mkdir(JSON_DIR)
 logging.basicConfig(level=logging.DEBUG, filename=LOG_FILE, format=fmt, datefmt='%Y-%m-%d %H:%M:%S')
 warnings.simplefilter(action='ignore', category=FutureWarning)
 
 
 class syntheticMaintPValidate:
-    def __init__(self, name, description, path=LIVE_RESULTS_DIR):
+    def __init__(self, name, description, path=JSON_DIR):
         self.name = name
         self.description = description
         self.reason = ""
@@ -134,7 +135,7 @@ class syntheticMaintPValidate:
         if not os.path.isdir(self.path):
             os.mkdir(self.path)
         with open(os.path.join(self.path, self.filename), "w") as f:
-            json.dump(self.buildResult(), f, indent=4)
+            json.dump(self.buildResult(), f, indent=2)
         return "{}/{}".format(self.path, self.filename)
 
 
@@ -1105,20 +1106,22 @@ def print_result(title, result, msg='',
                  unformatted_headers=None, unformatted_data=None,
                  recommended_action='',
                  doc_url='',
-                 adjust_title=False):
-    synth = syntheticMaintPValidate(title, "")
-    synth.updateWithResults(
-        result=result,
-        recommended_action=recommended_action,
-        reason=msg,
-        header="",
-        footer=doc_url,
-        column=headers,
-        row=data,
-        unformatted_column=unformatted_headers,
-        unformatted_rows=unformatted_data,
-    )
-    synth.writeResult()
+                 adjust_title=False,
+                 json_output=True):
+    if json_output:
+        synth = syntheticMaintPValidate(title, "")
+        synth.updateWithResults(
+            result=result,
+            recommended_action=recommended_action,
+            reason=msg,
+            header="",
+            footer=doc_url,
+            column=headers,
+            row=data,
+            unformatted_column=unformatted_headers,
+            unformatted_rows=unformatted_data,
+        )
+        synth.writeResult()
     padding = 120 - len(title) - len(msg)
     if adjust_title: padding += len(title) + 18
     output = '{}{:>{}}'.format(msg, result, padding)
@@ -1181,6 +1184,7 @@ def icurl(apitype, query, page_size=100000):
 
 
 def get_credentials():
+    prints('To use a non-default Login Domain, enter apic#DOMAIN\\\\USERNAME')
     while True:
         usr = input('Enter username for APIC login          : ')
         if usr: break
@@ -2037,8 +2041,9 @@ def switch_ssd_check(index, total_checks, **kwargs):
     print_result(title, result, msg, headers, data, unformatted_headers, unformatted_data)
     return result
 
+
 # Connection based check
-def apic_ssd_check(index, total_checks, cversion, **kwargs):
+def apic_ssd_check(index, total_checks, cversion, username, password, **kwargs):
     title = 'APIC SSD Health'
     result = FAIL_UF
     msg = ''
@@ -2079,7 +2084,7 @@ def apic_ssd_check(index, total_checks, cversion, **kwargs):
                     c.connect()
                 except Exception as e:
                     data.append([attr['id'], attr['name'], '-', '-', '-', str(e)])
-                    print_result(node_title, ERROR)
+                    print_result(node_title, ERROR, json_output=False)
                     has_error = True
                     continue
                 try:
@@ -2087,7 +2092,7 @@ def apic_ssd_check(index, total_checks, cversion, **kwargs):
                         'grep -oE "SSD Wearout Indicator is [0-9]+"  /var/log/dme/log/svc_ifc_ae.bin.log | tail -1')
                 except Exception as e:
                     data.append([attr['id'], attr['name'], '-', '-', '-', str(e)])
-                    print_result(node_title, ERROR)
+                    print_result(node_title, ERROR, json_output=False)
                     has_error = True
                     continue
 
@@ -2099,12 +2104,12 @@ def apic_ssd_check(index, total_checks, cversion, **kwargs):
                                      wearout, recommended_action])
                         report_other = True
 
-                        print_result(node_title, DONE)
+                        print_result(node_title, DONE, json_output=False)
                         continue
                     if report_other:
                         data.append([pod_id, node_id, "Solid State Disk",
                                      wearout, "No Action Required"])
-                print_result(node_title, DONE)
+                print_result(node_title, DONE, json_output=False)
     else:
         headers = ["Fault", "Pod", "Node", "Storage Unit", "% lifetime remaining", "Recommended Action"]
         unformatted_headers = ["Fault", "Fault DN", "% lifetime remaining", "Recommended Action"]
@@ -2685,6 +2690,7 @@ def lldp_with_infra_vlan_mismatch_check(index, total_checks, **kwargs):
     print_result(title, result, msg, headers, data, unformatted_headers, unformatted_data)
     return result
 
+
 # Connection based check
 def apic_version_md5_check(index, total_checks, tversion, username, password, **kwargs):
     title = 'APIC Target version image and MD5 hash'
@@ -2733,7 +2739,7 @@ def apic_version_md5_check(index, total_checks, tversion, username, password, **
             c.connect()
         except Exception as e:
             data.append([apic_name, '-', '-', str(e), '-'])
-            print_result(node_title, ERROR)
+            print_result(node_title, ERROR, json_output=False)
             has_error = True
             continue
 
@@ -2743,12 +2749,12 @@ def apic_version_md5_check(index, total_checks, tversion, username, password, **
         except Exception as e:
             data.append([apic_name, '-', '-',
                          'ls command via ssh failed due to:{}'.format(str(e)), '-'])
-            print_result(node_title, ERROR)
+            print_result(node_title, ERROR, json_output=False)
             has_error = True
             continue
         if "No such file or directory" in c.output:
             data.append([apic_name, str(tversion), '-', 'image not found', recommended_action])
-            print_result(node_title, FAIL_UF)
+            print_result(node_title, FAIL_UF, json_output=False)
             continue
 
         try:
@@ -2757,12 +2763,12 @@ def apic_version_md5_check(index, total_checks, tversion, username, password, **
         except Exception as e:
             data.append([apic_name, str(tversion), '-',
                          'failed to check md5sum via ssh due to:{}'.format(str(e)), '-'])
-            print_result(node_title, ERROR)
+            print_result(node_title, ERROR, json_output=False)
             has_error = True
             continue
         if "No such file or directory" in c.output:
             data.append([apic_name, str(tversion), '-', 'md5sum file not found', recommended_action])
-            print_result(node_title, FAIL_UF)
+            print_result(node_title, FAIL_UF, json_output=False)
             continue
         for line in c.output.split("\n"):
             words = line.split()
@@ -2775,11 +2781,11 @@ def apic_version_md5_check(index, total_checks, tversion, username, password, **
                 break
         else:
             data.append([apic_name, str(tversion), '-', 'unexpected output when checking md5sum file', recommended_action])
-            print_result(node_title, ERROR)
+            print_result(node_title, ERROR, json_output=False)
             has_error = True
             continue
 
-        print_result(node_title, DONE)
+        print_result(node_title, DONE, json_output=False)
     if len(set(md5s)) > 1:
         for name, md5 in zip(md5_names, md5s):
             data.append([name, str(tversion), md5, 'md5sum do not match on all APICs', recommended_action])
@@ -2789,6 +2795,7 @@ def apic_version_md5_check(index, total_checks, tversion, username, password, **
         result = PASS
     print_result(title, result, msg, headers, data, adjust_title=True)
     return result
+
 
 # Connection Based Check
 def standby_apic_disk_space_check(index, total_checks, **kwargs):
@@ -3979,12 +3986,12 @@ def fabric_port_down_check(index, total_checks, **kwargs):
     recommended_action = 'Identify if these ports are needed for redundancy and reason for being down'
     doc_url = 'https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations#fabric-port-is-down'
     print_title(title, index, total_checks)
-    
-    fault_api =  'faultInst.json'
+
+    fault_api = 'faultInst.json'
     fault_api += '?&query-target-filter=and(eq(faultInst.code,"F1394")'
     fault_api += ',eq(faultInst.rule,"ethpm-if-port-down-fabric"))'
 
-    faultInsts = icurl('class',fault_api)
+    faultInsts = icurl('class', fault_api)
     dn_re = node_regex + r'/.+/phys-\[(?P<int>eth\d/\d+)\]'
 
     for faultInst in faultInsts:
@@ -4018,16 +4025,18 @@ def fabric_dpp_check(index, total_checks, tversion, **kwargs):
     if not tversion:
         print_result(title, MANUAL, "Target version not supplied. Skipping.")
         return MANUAL
-    
-    lbpol_api =  'lbpPol.json'
+
+    lbpol_api = 'lbpPol.json'
     lbpol_api += '?query-target-filter=eq(lbpPol.pri,"on")'
 
     lbpPol = icurl('class', lbpol_api)
     if lbpPol:
-        if ((tversion.newer_than("5.1(1h)") and tversion.older_than("5.2(8e)")) or 
-            (tversion.major1 == "6" and tversion.older_than("6.0(3d)"))):
-                result = FAIL_O
-                data.append(["CSCwf05073", "Target Version susceptible to Defect"])
+        if (
+            (tversion.newer_than("5.1(1h)") and tversion.older_than("5.2(8e)")) or
+            (tversion.major1 == "6" and tversion.older_than("6.0(3d)"))
+        ):
+            result = FAIL_O
+            data.append(["CSCwf05073", "Target Version susceptible to Defect"])
 
     print_result(title, result, msg, headers, data, recommended_action=recommended_action, doc_url=doc_url)
     return result
@@ -4080,7 +4089,7 @@ def subnet_scope_check(index, total_checks, cversion, **kwargs):
     print_title(title, index, total_checks)
 
     if cversion.older_than("4.2(6d)") or (cversion.major1 == "5" and cversion.older_than("5.1(1h)")):
-        epg_api =  'fvAEPg.json?'
+        epg_api = 'fvAEPg.json?'
         epg_api += 'rsp-subtree=children&rsp-subtree-class=fvSubnet&rsp-subtree-include=required'
 
         fvAEPg = icurl('class', epg_api)
@@ -4088,7 +4097,7 @@ def subnet_scope_check(index, total_checks, cversion, **kwargs):
             print_result(title, NA, "0 EPG Subnets found. Skipping.")
             return NA
 
-        bd_api =  'fvBD.json'
+        bd_api = 'fvBD.json'
         bd_api += '?rsp-subtree=children&rsp-subtree-class=fvSubnet&rsp-subtree-include=required'
 
         fvBD = icurl('class', bd_api)
@@ -4161,10 +4170,10 @@ def rtmap_comm_match_defect_check(index, total_checks, tversion, **kwargs):
                         has_dest = True
                 if has_comm and not has_dest:
                     subj_dn_list.append(dn)
-            
+
             # Now check if affected match statement is in use by any route-map
             if len(subj_dn_list) > 0:
-                rtctrlCtxPs = icurl('class','rtctrlCtxP.json?rsp-subtree=full&rsp-subtree-class=rtctrlRsCtxPToSubjP,rtctrlRsScopeToAttrP&rsp-subtree-include=required')
+                rtctrlCtxPs = icurl('class', 'rtctrlCtxP.json?rsp-subtree=full&rsp-subtree-class=rtctrlRsCtxPToSubjP,rtctrlRsScopeToAttrP&rsp-subtree-include=required')
                 if rtctrlCtxPs:
                     for rtctrlCtxP in rtctrlCtxPs:
                         has_affected_subj = False
@@ -4181,7 +4190,7 @@ def rtmap_comm_match_defect_check(index, total_checks, tversion, **kwargs):
                         if has_affected_subj and has_set:
                             dn = rtctrlCtxP['rtctrlCtxP']['attributes']['dn']
                             parent_dn = '/'.join(dn.rsplit('/', 1)[:-1])
-                            data.append([parent_dn,subj_dn,"Route-map has community match statement but no prefix list."])
+                            data.append([parent_dn, subj_dn, "Route-map has community match statement but no prefix list."])
 
         if data:
             result = FAIL_O
@@ -4202,8 +4211,8 @@ def fabricPathEp_target_check(index, total_checks, **kwargs):
     fabricPathEp_regex = r"topology/pod-\d+/(?:\w+)?paths-\d+(?:-\d+)?(?:/ext(?:\w+)?paths-(?P<fexA>\d+)(?:-(?P<fexB>\d+))?)?/pathep-\[(?P<path>.+)\]"
     eth_regex = r'eth(?P<first>\d+)/(?P<second>\d+)(?:/(?P<third>\d+))?'
 
-    hpath_api =  'infraRsHPathAtt.json'
-    oosPorts_api =  'fabricRsOosPath.json'
+    hpath_api = 'infraRsHPathAtt.json'
+    oosPorts_api = 'fabricRsOosPath.json'
     infraRsHPathAtt = icurl('class', hpath_api)
     fabricRsOosPath = icurl('class', oosPorts_api)
 
@@ -4280,7 +4289,7 @@ def lldp_custom_int_description_defect_check(index, total_checks, tversion, **kw
 
     if tversion.major1 == '6' and tversion.older_than('6.0(3a)'):
         custom_int_count = icurl('class', 'infraPortBlk.json?query-target-filter=ne(infraPortBlk.descr,"")&rsp-subtree-include=count')[0]['moCount']['attributes']['count']
-        lazy_vmm_count = icurl('class','fvRsDomAtt.json?query-target-filter=and(eq(fvRsDomAtt.tCl,"vmmDomP"),eq(fvRsDomAtt.resImedcy,"lazy"))&rsp-subtree-include=count')[0]['moCount']['attributes']['count']
+        lazy_vmm_count = icurl('class', 'fvRsDomAtt.json?query-target-filter=and(eq(fvRsDomAtt.tCl,"vmmDomP"),eq(fvRsDomAtt.resImedcy,"lazy"))&rsp-subtree-include=count')[0]['moCount']['attributes']['count']
 
         if int(custom_int_count) > 0 and int(lazy_vmm_count) > 0:
             result = FAIL_O
@@ -4494,8 +4503,8 @@ def validate_32_64_bit_image_check(index, total_checks, cversion, tversion, **kw
     if cversion.newer_than("6.0(2a)") and tversion.newer_than("6.0(2a)"):
         result_32 = result_64 = "Not Found"
         target_sw_ver = 'n9000-1' + tversion.version
-        firmware_api =	'firmwareFirmware.json'
-        firmware_api +=	'?query-target-filter=eq(firmwareFirmware.fullVersion,"%s")' % (target_sw_ver)  
+        firmware_api = 'firmwareFirmware.json'
+        firmware_api += '?query-target-filter=eq(firmwareFirmware.fullVersion,"%s")' % (target_sw_ver)
         firmwares = icurl('class', firmware_api)
 
         for firmware in firmwares:
@@ -4613,7 +4622,7 @@ def cloudsec_encryption_depr_check(index, total_checks, tversion, **kwargs):
     doc_url = 'https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations#cloudsec-encryption-deprecated'
     print_title(title, index, total_checks)
 
-    cloudsec_api =  'cloudsecPreSharedKey.json'
+    cloudsec_api = 'cloudsecPreSharedKey.json'
 
     if not tversion:
         print_result(title, MANUAL, "Target version not supplied. Skipping.")
@@ -4644,7 +4653,7 @@ def out_of_service_ports_check(index, total_checks, **kwargs):
     title = 'Out-of-Service Ports'
     result = PASS
     msg = ''
-    headers = ["Pod ID", "Node ID", "Port ID", "Operational State", "Usage" ]
+    headers = ["Pod ID", "Node ID", "Port ID", "Operational State", "Usage"]
     data = []
     recommended_action = 'Remove Out-of-service Policy on identified "up" ports or they will remain "down" after switch Upgrade'
     doc_url = 'https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#out-of-service-ports'
@@ -4664,7 +4673,7 @@ def out_of_service_ports_check(index, total_checks, **kwargs):
             data.append([node_data.group("pod"), node_data.group("node"), node_data.group("port"), oper_st, usage])
 
     if data:
-       result = FAIL_O 
+        result = FAIL_O
 
     print_result(title, result, msg, headers, data, recommended_action=recommended_action, doc_url=doc_url)
     return result
@@ -4683,26 +4692,26 @@ def fc_ex_model_check(index, total_checks, tversion, **kwargs):
     fcEntity_api = "fcEntity.json"
     fabricNode_api = 'fabricNode.json'
     fabricNode_api += '?query-target-filter=wcard(fabricNode.model,".*EX")'
-    
+
     if not tversion:
         print_result(title, MANUAL, "Target version not supplied. Skipping.")
         return MANUAL
-    
+
     if (tversion.newer_than("6.0(7a)") and tversion.older_than("6.0(9c)")) or tversion.same_as("6.1(1f)"):
-        fcEntitys =  icurl('class', fcEntity_api)
+        fcEntitys = icurl('class', fcEntity_api)
         fc_nodes = []
         if fcEntitys:
             for fcEntity in fcEntitys:
                 fc_nodes.append(fcEntity['fcEntity']['attributes']['dn'].split('/sys')[0])
-            
+
         if fc_nodes:
             fabricNodes = icurl('class', fabricNode_api)
             for node in fabricNodes:
-                 node_dn = node['fabricNode']['attributes']['dn']
-                 if node_dn in fc_nodes:
-                      model = node['fabricNode']['attributes']['model']
-                      if model in ["N9K-C93180YC-EX", "N9K-C93108TC-EX", "N9K-C93108LC-EX"]:
-                            data.append([node_dn, model])
+                node_dn = node['fabricNode']['attributes']['dn']
+                if node_dn in fc_nodes:
+                    model = node['fabricNode']['attributes']['model']
+                    if model in ["N9K-C93180YC-EX", "N9K-C93108TC-EX", "N9K-C93108LC-EX"]:
+                        data.append([node_dn, model])
     if data:
         result = FAIL_O
     print_result(title, result, msg, headers, data, recommended_action=recommended_action, doc_url=doc_url)
@@ -4734,7 +4743,7 @@ def tep_to_tep_ac_counter_check(index, total_checks, **kwargs):
     if data:
         result = FAIL_UF
 
-    print_result(title, result, msg, headers, data, recommended_action=recommended_action, doc_url=doc_url)         
+    print_result(title, result, msg, headers, data, recommended_action=recommended_action, doc_url=doc_url)
     return result
 
 
@@ -4793,15 +4802,15 @@ def stale_decomissioned_spine_check(index, total_checks, tversion, **kwargs):
     doc_url = 'https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#stale-decommissioned-spine'
     print_title(title, index, total_checks)
 
-    decomissioned_api ='fabricRsDecommissionNode.json'
+    decomissioned_api = 'fabricRsDecommissionNode.json'
 
     active_spine_api = 'topSystem.json'
-    active_spine_api +=	'?query-target-filter=eq(topSystem.role,"spine")'
+    active_spine_api += '?query-target-filter=eq(topSystem.role,"spine")'
 
     if not tversion:
         print_result(title, MANUAL, "Target version not supplied. Skipping.")
         return MANUAL
-    
+
     if tversion.newer_than("5.2(3d)") and tversion.older_than("6.0(3d)"):
         decomissioned_switches = icurl('class', decomissioned_api)
         if decomissioned_switches:
@@ -4832,11 +4841,11 @@ def n9408_model_check(index, total_checks, tversion, **kwargs):
 
     eqptCh_api = 'eqptCh.json'
     eqptCh_api += '?query-target-filter=eq(eqptCh.model,"N9K-C9400-SW-GX2A")'
-    
+
     if not tversion:
         print_result(title, MANUAL, "Target version not supplied. Skipping.")
         return MANUAL
-    
+
     if tversion.newer_than("6.1(3a)"):
         eqptCh = icurl('class', eqptCh_api)
         for node in eqptCh:
@@ -4846,7 +4855,7 @@ def n9408_model_check(index, total_checks, tversion, **kwargs):
     if data:
         result = FAIL_O
 
-    print_result(title, result, msg, headers, data, recommended_action=recommended_action, doc_url=doc_url)         
+    print_result(title, result, msg, headers, data, recommended_action=recommended_action, doc_url=doc_url)
     return result
 
 
@@ -4864,7 +4873,7 @@ def pbr_high_scale_check(index, total_checks, tversion, **kwargs):
     vnsAdjacencyDefCont_api = 'vnsAdjacencyDefCont.json'
     vnsSvcRedirEcmpBucketCons_api = 'vnsSvcRedirEcmpBucketCons.json'
     count_filter = '?rsp-subtree-include=count'
-    
+
     if not tversion:
         print_result(title, MANUAL, "Target version not supplied. Skipping.")
         return MANUAL
@@ -4872,7 +4881,7 @@ def pbr_high_scale_check(index, total_checks, tversion, **kwargs):
     if tversion.older_than("5.3(2c)"):
         vnsAdj = icurl('class', vnsAdjacencyDefCont_api+count_filter)
         vnsSvc = icurl('class', vnsSvcRedirEcmpBucketCons_api+count_filter)
-        
+
         vnsAdj_count = int(vnsAdj[0]['moCount']['attributes']['count'])
         vnsSvc_count = int(vnsSvc[0]['moCount']['attributes']['count'])
         total = vnsAdj_count + vnsSvc_count
@@ -4882,7 +4891,7 @@ def pbr_high_scale_check(index, total_checks, tversion, **kwargs):
     if data:
         result = FAIL_O
 
-    print_result(title, result, msg, headers, data, recommended_action=recommended_action, doc_url=doc_url)         
+    print_result(title, result, msg, headers, data, recommended_action=recommended_action, doc_url=doc_url)
     return result
 
 
@@ -4953,8 +4962,10 @@ def standby_sup_sync_check(index, total_checks, cversion, tversion, **kwargs):
         print_result(title, MANUAL, "Target version not supplied. Skipping.")
         return MANUAL
 
-    if  ((cversion.older_than("4.2(7t)") or (cversion.major_version == "5.2" and cversion.older_than("5.2(5d)")))
-        and ((tversion.major_version == "5.2" and tversion.older_than("5.2(7f)")) or tversion.newer_than("6.0(2h)"))):
+    if (
+        (cversion.older_than("4.2(7t)") or (cversion.major_version == "5.2" and cversion.older_than("5.2(5d)")))
+        and ((tversion.major_version == "5.2" and tversion.older_than("5.2(7f)")) or tversion.newer_than("6.0(2h)"))
+    ):
         eqptSupC = icurl('class', eqptSupC_api)
         for node in eqptSupC:
             node_dn = node['eqptSupC']['attributes']['dn']
@@ -4968,7 +4979,7 @@ def standby_sup_sync_check(index, total_checks, cversion, tversion, **kwargs):
     if data:
         result = FAIL_UF
 
-    print_result(title, result, msg, headers, data, recommended_action=recommended_action, doc_url=doc_url)         
+    print_result(title, result, msg, headers, data, recommended_action=recommended_action, doc_url=doc_url)
     return result
 
 
@@ -5005,7 +5016,7 @@ def equipment_disk_limits_exceeded(index, total_checks, **kwargs):
             data.append([dn_match.group('pod'), dn_match.group('node'), attributes['code'], percent, attributes['descr']])
         else:
             unformatted_data.append([attributes['dn'], percent, attributes['descr']])
-    
+
     if data or unformatted_data:
         result = FAIL_UF
 
@@ -5095,6 +5106,7 @@ def service_bd_forceful_routing_check(index, total_checks, cversion, tversion, *
     print_result(title, result, msg, headers, data, unformatted_headers, unformatted_data, recommended_action, doc_url)
     return result
 
+
 # Connection Base Check
 def observer_db_size_check(index, total_checks, username, password, **kwargs):
     title = 'Observer Database Size'
@@ -5127,7 +5139,7 @@ def observer_db_size_check(index, total_checks, username, password, **kwargs):
             c.connect()
         except Exception as e:
             data.append([attr['id'], attr['name'], str(e)])
-            print_result(node_title, ERROR)
+            print_result(node_title, ERROR, json_output=False)
             has_error = True
             continue
         try:
@@ -5135,7 +5147,7 @@ def observer_db_size_check(index, total_checks, username, password, **kwargs):
             c.cmd(cmd)
             if "No such file or directory" in c.output:
                 data.append([attr['id'], '/data2/dbstats/ not found', "Check user permissions or retry as 'apic#fallback\\\\admin'"])
-                print_result(node_title, ERROR)
+                print_result(node_title, ERROR, json_output=False)
                 has_error = True
                 continue
             dbstats = c.output.split("\n")
@@ -5146,10 +5158,10 @@ def observer_db_size_check(index, total_checks, username, password, **kwargs):
                     file_size = size_match.group("size")
                     file_name = "/data2/dbstats/" + size_match.group("file")
                     data.append([attr['id'], file_name, file_size])
-            print_result(node_title, DONE)
+            print_result(node_title, DONE, json_output=False)
         except Exception as e:
             data.append([attr['id'], attr['name'], str(e)])
-            print_result(node_title, ERROR)
+            print_result(node_title, ERROR, json_output=False)
             has_error = True
             continue
     if has_error:
@@ -5208,13 +5220,12 @@ def parse_args(args):
     return is_puv, tversion
 
 
-def prepare(is_puv, arg_tversion):
-    if is_puv:
-        username = password = None
-        if os.path.exists(LIVE_RESULTS_DIR) and os.path.isdir(LIVE_RESULTS_DIR):
-            shutil.rmtree(LIVE_RESULTS_DIR)
-    else:
-        prints('To use a non-default Login Domain, enter apic#DOMAIN\\\\USERNAME')
+def prepare(is_puv, arg_tversion, total_checks):
+    prints('    ==== %s%s, Script Version %s  ====\n' % (ts, tz, SCRIPT_VERSION))
+    prints('!!!! Check https://github.com/datacenter/ACI-Pre-Upgrade-Validation-Script for Latest Release !!!!\n')
+
+    username = password = None
+    if not is_puv:
         username, password = get_credentials()
     try:
         cversion = get_current_version()
@@ -5229,10 +5240,20 @@ def prepare(is_puv, arg_tversion):
     inputs = {'username': username, 'password': password,
               'cversion': cversion, 'tversion': tversion,
               'vpc_node_ids': vpc_nodes, 'sw_cversion': sw_cversion}
-    json_log = {"name": "PreupgradeCheck", "method": "standalone script", "datetime": ts + tz,
-                "script_version": str(SCRIPT_VERSION), "check_details": [],
-                'cversion': str(cversion), 'tversion': str(tversion), 'sw_cversion': str(sw_cversion)}
-    return inputs, json_log
+    metadata = {
+        "name": "PreupgradeCheck",
+        "method": "standalone script",
+        "datetime": ts + tz,
+        "script_version": str(SCRIPT_VERSION),
+        "cversion": str(cversion),
+        "tversion": str(tversion),
+        "sw_cversion": str(sw_cversion),
+        "is_puv": is_puv,
+        "total_checks": total_checks,
+    }
+    with open(META_FILE, "w") as f:
+        json.dump(metadata, f, indent=2)
+    return inputs
 
 
 def get_checks(is_puv):
@@ -5342,14 +5363,13 @@ def get_checks(is_puv):
     return conn_checks + api_checks
 
 
-def run_checks(checks, inputs, json_log):
+def run_checks(checks, inputs):
     summary_headers = [PASS, FAIL_O, FAIL_UF, MANUAL, POST, NA, ERROR, 'TOTAL']
     summary = {key: 0 if key != 'TOTAL' else len(checks) for key in summary_headers}
     for idx, check in enumerate(checks):
         try:
             r = check(idx + 1, len(checks), **inputs)
             summary[r] += 1
-            json_log["check_details"].append({"check_number": idx + 1, "name": check.__name__, "results": r})
         except KeyboardInterrupt:
             prints('\n\n!!! KeyboardInterrupt !!!\n')
             break
@@ -5371,12 +5391,8 @@ def run_checks(checks, inputs, json_log):
     for key in summary_headers:
         prints('{:{}} : {:2}'.format(key, max_header_len, summary[key]))
 
-    jsonString = json.dumps(json_log)
-    with open(JSON_FILE, 'w') as f:
-        f.write(jsonString)
-
     with open(SUMMARY_FILE, 'w') as f:
-        f.write(json.dumps(summary))
+        json.dump(summary, f, indent=2)
 
 
 def wrapup(is_puv):
@@ -5393,20 +5409,16 @@ def wrapup(is_puv):
     """.format(bundle=bundle_loc))
     prints('==== Script Version %s FIN ====' % (SCRIPT_VERSION))
 
-    if not is_puv and os.path.isdir(LIVE_RESULTS_DIR):
-        shutil.rmtree(LIVE_RESULTS_DIR)
-    shutil.rmtree(DIR)
+    # puv integration needs to keep reading files from `JSON_DIR` under `DIR`.
+    if not is_puv and os.path.isdir(DIR):
+        shutil.rmtree(DIR)
 
 
 def main(args=None):
     is_puv, arg_tversion = parse_args(args)
-
-    prints('    ==== %s%s, Script Version %s  ====\n' % (ts, tz, SCRIPT_VERSION))
-    prints('!!!! Check https://github.com/datacenter/ACI-Pre-Upgrade-Validation-Script for Latest Release !!!!\n')
-
-    inputs, json_log = prepare(is_puv, arg_tversion)
     checks = get_checks(is_puv)
-    run_checks(checks, inputs, json_log)
+    inputs = prepare(is_puv, arg_tversion, len(checks))
+    run_checks(checks, inputs)
     wrapup(is_puv)
 
 

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -1235,19 +1235,21 @@ def get_target_version():
         return None
 
 
-def get_vpc_nodes(**kwargs):
+def get_vpc_nodes():
     """ Returns list of VPC Node IDs; ['101', '102', etc...] """
-    prints("Collecting VPC Node IDs...\n")
+    prints("Collecting VPC Node IDs...", end='')
     vpc_nodes = []
-
-    prot_pols = kwargs.get("fabricNodePEp.json", None)
-    if not prot_pols:
-        prot_pols = icurl('class', 'fabricNodePEp.json')
-
-    if prot_pols:
-        for vpc_node in prot_pols:
-            vpc_nodes.append(vpc_node['fabricNodePEp']['attributes']['id'])
-
+    prot_pols = icurl('class', 'fabricNodePEp.json')
+    for vpc_node in prot_pols:
+        vpc_nodes.append(vpc_node['fabricNodePEp']['attributes']['id'])
+    vpc_nodes.sort()
+    # Display up to 4 node IDs
+    max_display = 4
+    if len(vpc_nodes) <= max_display:
+        prints('%s\n' % ", ".join(vpc_nodes))
+    else:
+        omitted_count = len(vpc_nodes) - max_display
+        prints('%s, ... (and %d more)\n' % (", ".join(vpc_nodes[:max_display]), omitted_count))
     return vpc_nodes
 
 

--- a/tests/test_get_vpc_node.py
+++ b/tests/test_get_vpc_node.py
@@ -41,15 +41,40 @@ data = [
     }
 ]
 
+data2 = [
+    {"fabricNodePEp": {"attributes": {"dn": "uni/fabric/protpol/expgep-101-102/nodepep-101", "id": "101"}}},
+    {"fabricNodePEp": {"attributes": {"dn": "uni/fabric/protpol/expgep-101-102/nodepep-102", "id": "102"}}},
+    {"fabricNodePEp": {"attributes": {"dn": "uni/fabric/protpol/expgep-103-104/nodepep-103", "id": "103"}}},
+    {"fabricNodePEp": {"attributes": {"dn": "uni/fabric/protpol/expgep-103-104/nodepep-104", "id": "104"}}},
+    {"fabricNodePEp": {"attributes": {"dn": "uni/fabric/protpol/expgep-105-106/nodepep-105", "id": "105"}}},
+    {"fabricNodePEp": {"attributes": {"dn": "uni/fabric/protpol/expgep-105-106/nodepep-106", "id": "106"}}},
+]
+
 
 @pytest.mark.parametrize(
-    "icurl_outputs, expected_result",
+    "icurl_outputs, expected_result, expected_stdout",
     [
         (
+            {fabricNodePEps: []},
+            [],
+            "Collecting VPC Node IDs...\n\n",
+        ),
+        (
             {fabricNodePEps: data},
-            ["101", "103", "204", "206"]
+            ["101", "103", "204", "206"],
+            "Collecting VPC Node IDs...101, 103, 204, 206\n\n",
+        ),
+        (
+            {fabricNodePEps: data2},
+            ["101", "102", "103", "104", "105", "106"],
+            "Collecting VPC Node IDs...101, 102, 103, 104, ... (and 2 more)\n\n",
         )
     ]
 )
-def test_get_vpc_nodes(mock_icurl, expected_result):
-    assert set(script.get_vpc_nodes()) == set(expected_result)
+def test_get_vpc_nodes(capsys, mock_icurl, expected_result, expected_stdout):
+    vpc_nodes = script.get_vpc_nodes()
+    assert vpc_nodes == expected_result
+
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert captured.out == expected_stdout

--- a/tests/test_parse_args.py
+++ b/tests/test_parse_args.py
@@ -1,0 +1,54 @@
+import pytest
+import importlib
+import sys
+
+script = importlib.import_module("aci-preupgrade-validation-script")
+AciVersion = script.AciVersion
+
+
+def test_no_args():
+    # When `None` or nothing is passed to `ArgumentParser.parse_args()`, the `argparse`
+    # module reads `sys.argv[1:]` which should return an empty list when a script is
+    # run without any command-line arguments. However, in pytest, `sys.argv[1:]` is
+    # the arguments to the pytest command which may not be empty.
+    # To simulate the script being run without any command-line arguments,
+    # we set `sys.argv[1:]` to an empty list when `args` is `None`.
+    sys.argv[1:] = []
+    is_puv, tversion = script.parse_args(args=None)
+    assert is_puv is False
+    assert tversion is None
+
+
+@pytest.mark.parametrize(
+    "args, expected_result",
+    [
+        ([], False),
+        (["--puv"], True),
+    ],
+)
+def test_puv(args, expected_result):
+    is_puv, tversion = script.parse_args(args)
+    assert is_puv == expected_result
+
+
+@pytest.mark.parametrize(
+    "args, expected_result",
+    [
+        ([], None),
+        (["-t", "6.2(1a)"], AciVersion("6.2(1a)")),
+        (["-t", "16.2(1a)"], AciVersion("6.2(1a)")),
+        (["-t", "n9000-16.2(1a).bin"], AciVersion("6.2(1a)")),
+        (["-t", "aci-apic-dk9.6.2.1a.bin"], AciVersion("6.2(1a)")),
+    ],
+)
+def test_tversion(args, expected_result):
+    is_puv, tversion = script.parse_args(args)
+    if tversion is not None:
+        assert isinstance(tversion, AciVersion)
+    assert str(tversion) == str(expected_result)
+
+
+def test_tversion_invald():
+    with pytest.raises(SystemExit):
+        with pytest.raises(RuntimeError):
+            script.parse_args(args=["-t", "invalid_version"])

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -1,0 +1,167 @@
+import pytest
+import importlib
+import logging
+
+script = importlib.import_module("aci-preupgrade-validation-script")
+AciVersion = script.AciVersion
+
+
+@pytest.fixture(autouse=True)
+def mock_get_credentials(monkeypatch):
+    """Mock the get_credentials function to return a fixed username and password."""
+
+    def _mock_get_credentials():
+        return ("admin", "mypassword")
+
+    monkeypatch.setattr(script, "get_credentials", _mock_get_credentials)
+
+
+@pytest.fixture(autouse=True)
+def mock_get_target_version(monkeypatch):
+    """
+    Mock `get_target_version()` to return a fixed target version.
+    Used when the script is run without the `-t` option which is simulated by
+    `arg_tversion`.
+    Not using `mock_icurl` because this function involves a user interaction to
+    select a version.
+    """
+
+    def _mock_get_target_version():
+        return AciVersion("6.2(1a)")
+
+    monkeypatch.setattr(script, "get_target_version", _mock_get_target_version)
+
+
+outputs = {
+    "cversion": [
+        {
+            "firmwareCtrlrRunning": {
+                "attributes": {
+                    "dn": "topology/pod-1/node-1/sys/ctrlrfwstatuscont/ctrlrrunning",
+                    "version": "6.1(1a)",
+                }
+            }
+        }
+    ],
+    "switch_version": [
+        {"firmwareRunning": {"attributes": {"peVer": "6.1(1a)", "version": "n9000-16.1(1a)"}}},
+        {"firmwareRunning": {"attributes": {"peVer": "6.0(9d)", "version": "n9000-16.0(9d)"}}},
+    ],
+    "vpc_nodes": [
+        {"fabricNodePEp": {"attributes": {"dn": "uni/fabric/protpol/expgep-101-102/nodepep-101", "id": "101"}}},
+        {"fabricNodePEp": {"attributes": {"dn": "uni/fabric/protpol/expgep-101-102/nodepep-102", "id": "102"}}},
+    ],
+}
+
+
+@pytest.mark.parametrize(
+    "icurl_outputs, is_puv, arg_tversion, expected_result",
+    [
+        # Default, no argparse arguments
+        (
+            {
+                "firmwareCtrlrRunning.json": outputs["cversion"],
+                "firmwareRunning.json": outputs["switch_version"],
+                "fabricNodePEp.json": outputs["vpc_nodes"],
+            },
+            False,
+            None,
+            {"username": "admin", "password": "mypassword", "cversion": AciVersion("6.1(1a)"), "tversion": AciVersion("6.2(1a)"), "sw_cversion": AciVersion("6.0(9d)"), "vpc_node_ids": ["101", "102"]},
+        ),
+        # `is_puv` is True (i.e. --puv)
+        # No `get_credentials()`, no username nor password
+        (
+            {
+                "firmwareCtrlrRunning.json": outputs["cversion"],
+                "firmwareRunning.json": outputs["switch_version"],
+                "fabricNodePEp.json": outputs["vpc_nodes"],
+            },
+            True,
+            None,
+            {"username": None, "password": None, "cversion": AciVersion("6.1(1a)"), "tversion": AciVersion("6.2(1a)"), "sw_cversion": AciVersion("6.0(9d)"), "vpc_node_ids": ["101", "102"]},
+        ),
+        # `arg_tversion` is provided (i.e. -t 6.1(4a))
+        # The version `get_target_version()` is ignored.
+        (
+            {
+                "firmwareCtrlrRunning.json": outputs["cversion"],
+                "firmwareRunning.json": outputs["switch_version"],
+                "fabricNodePEp.json": outputs["vpc_nodes"],
+            },
+            False,
+            AciVersion("6.1(4a)"),
+            {"username": "admin", "password": "mypassword", "cversion": AciVersion("6.1(1a)"), "tversion": AciVersion("6.1(4a)"), "sw_cversion": AciVersion("6.0(9d)"), "vpc_node_ids": ["101", "102"]},
+        ),
+    ],
+)
+def test_prepare(mock_icurl, is_puv, arg_tversion, expected_result):
+    inputs, json_log = script.prepare(is_puv, arg_tversion)
+    for key, value in expected_result.items():
+        if "version" in key:
+            assert isinstance(inputs[key], AciVersion)
+            assert str(inputs[key]) == str(value)
+        else:
+            assert inputs[key] == value
+
+
+@pytest.mark.parametrize(
+    "icurl_outputs, is_puv, arg_tversion, expected_result",
+    [
+        # `get_cversion()` failure
+        (
+            {
+                "firmwareCtrlrRunning.json": [{"error": {"attributes": {"code": "400", "text": "Request failed, unresolved class for firmwareCtrlrRunning_fake"}}}],
+                "firmwareRunning.json": outputs["switch_version"],
+                "fabricNodePEp.json": outputs["vpc_nodes"],
+            },
+            False,
+            None,
+            """\
+Checking current APIC version...
+
+Error: Your current ACI version does not have requested class
+Initial query failed. Ensure APICs are healthy. Ending script run.
+""",
+        ),
+        # `get_switch_version()` failure
+        (
+            {
+                "firmwareCtrlrRunning.json": outputs["cversion"],
+                "firmwareRunning.json": [{"error": {"attributes": {"code": "400", "text": "Request failed, unresolved class for firmwareRunning_fake"}}}],
+                "fabricNodePEp.json": outputs["vpc_nodes"],
+            },
+            False,
+            None,
+            """\
+Gathering Lowest Switch Version from Firmware Repository...
+
+Error: Your current ACI version does not have requested class
+Initial query failed. Ensure APICs are healthy. Ending script run.
+""",
+        ),
+        # `get_vpc_nodes()` failure
+        (
+            {
+                "firmwareCtrlrRunning.json": outputs["cversion"],
+                "firmwareRunning.json": outputs["switch_version"],
+                "fabricNodePEp.json": [{"error": {"attributes": {"code": "400", "text": "Request failed, unresolved class for fabricNodePEp_fake"}}}],
+            },
+            False,
+            None,
+            """\
+Collecting VPC Node IDs...
+
+Error: Your current ACI version does not have requested class
+Initial query failed. Ensure APICs are healthy. Ending script run.
+""",
+        ),
+    ],
+)
+def test_prepare_exception(capsys, caplog, mock_icurl, is_puv, arg_tversion, expected_result):
+    caplog.set_level(logging.CRITICAL)
+    with pytest.raises(SystemExit):
+        with pytest.raises(Exception):
+            script.prepare(is_puv, arg_tversion)
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert captured.out.endswith(expected_result)

--- a/tests/test_run_checks.py
+++ b/tests/test_run_checks.py
@@ -1,0 +1,75 @@
+import importlib
+import logging
+
+script = importlib.import_module("aci-preupgrade-validation-script")
+AciVersion = script.AciVersion
+
+
+def check_builder(func_name, title, result):
+    def _check(index, total_checks, **kwargs):
+        _check.__name__ = func_name
+        script.print_title(title, index, total_checks)
+        if result == script.ERROR:
+            raise Exception("This is a test exception to result in `script.ERROR`.")
+        else:
+            script.print_result(title, result)
+            return result
+
+    return _check
+
+
+fake_checks = [
+    check_builder(func_name, title, result)
+    for func_name, title, result in [
+        ("check1", "Test Check 1", script.PASS),
+        ("check2", "Test Check 2", script.FAIL_O),
+        ("check3", "Test Check 3", script.FAIL_UF),
+        ("check4", "Test Check 4", script.MANUAL),
+        ("check5", "Test Check 5", script.POST),
+        ("check6", "Test Check 6", script.NA),
+        ("check7", "Test Check 7", script.ERROR),
+        ("check8", "Test Check 8", script.PASS),
+    ]
+]
+
+
+fake_inputs = {
+    "username": "admin",
+    "password": "mypassword",
+    "cversion": AciVersion("6.1(1a)"),
+    "tversion": AciVersion("6.2(1a)"),
+    "sw_cversion": AciVersion("6.1(1a)"),
+    "vpc_node_ids": ["101", "102"],
+}
+
+
+def test_run_checks(capsys, caplog):
+    caplog.set_level(logging.CRITICAL)  # Skip logging.exceptions in pytest output as it is expected.
+    script.run_checks(fake_checks, fake_inputs, {"check_details": []})
+    captured = capsys.readouterr()
+    print(captured.out)
+    assert (
+        captured.out
+        == """\
+[Check  1/8] Test Check 1...                                                                                                         PASS
+[Check  2/8] Test Check 2...                                                                                      FAIL - OUTAGE WARNING!!
+[Check  3/8] Test Check 3...                                                                                     FAIL - UPGRADE FAILURE!!
+[Check  4/8] Test Check 4...                                                                                        MANUAL CHECK REQUIRED
+[Check  5/8] Test Check 5...                                                                                  POST UPGRADE CHECK REQUIRED
+[Check  6/8] Test Check 6...                                                                                                          N/A
+[Check  7/8] Test Check 7... 
+                    ... Unexpected Error: This is a test exception to result in `script.ERROR`.                                   ERROR !!
+[Check  8/8] Test Check 8...                                                                                                         PASS
+
+=== Summary Result ===
+
+PASS                        :  2
+FAIL - OUTAGE WARNING!!     :  1
+FAIL - UPGRADE FAILURE!!    :  1
+MANUAL CHECK REQUIRED       :  1
+POST UPGRADE CHECK REQUIRED :  1
+N/A                         :  1
+ERROR !!                    :  1
+TOTAL                       :  8
+"""  # noqa: W291
+    )

--- a/tests/test_run_checks.py
+++ b/tests/test_run_checks.py
@@ -45,7 +45,7 @@ fake_inputs = {
 
 def test_run_checks(capsys, caplog):
     caplog.set_level(logging.CRITICAL)  # Skip logging.exceptions in pytest output as it is expected.
-    script.run_checks(fake_checks, fake_inputs, {"check_details": []})
+    script.run_checks(fake_checks, fake_inputs)
     captured = capsys.readouterr()
     print(captured.out)
     assert (


### PR DESCRIPTION
* Split the check execution logic under `if __name__ == "__main__":` into different functions for pytest
* Add pytest for them
* Clean up `get_vpc_nodes()` and its pytest
* Retire `json_log` and use synth result JSON per rule for both PUV and regular use cases
* Fix linting issues from `flake8`