### PR TITLE
issue 275 fixed

### DIFF
--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -131,6 +131,7 @@ Items                                         | Faults         | This Script    
 [Global AES Encryption][c21]                          | :white_check_mark: | :white_check_mark: 6.1(2) | :no_entry_sign:
 [Service Graph BD Forceful Routing][c22]              | :white_check_mark: | :no_entry_sign:           | :no_entry_sign:
 [AVE End-of-life][c23]                                | :white_check_mark: | :no_entry_sign:           | :no_entry_sign:
+[Host interface policy set to auto][c24]              | :white_check_mark: | :no_entry_sign:           | :no_entry_sign:
 
 
 [c1]: #vpc-paired-leaf-switches
@@ -156,6 +157,7 @@ Items                                         | Faults         | This Script    
 [c21]: #global-aes-encryption
 [c22]: #service-graph-bd-forceful-routing
 [c23]: #ave-end-of-life
+[c24]: #host-interface-policy-set-to-auto
 
 ### Defect Condition Checks
 
@@ -2222,6 +2224,13 @@ As outlined in the [End-of-Sale and End-of-Life Announcement for Cisco Applicati
 If planning an upgrade to 6.0+, review the [Cisco ACI Virtual Edge Migration Guide][56] and complete a domain migration prior to performing the upgrade.
 
 
+### Host interface policy set to auto
+As detailed in the [Cisco Apic Basic Configuration guide][59] a Link level Policy is recommended to have the speed set to "inherit".
+With this value, Cisco Apic determines the speed based on the transceiver inserted.
+
+In case the link speed is set to "auto" , interfaces may not come up after an upgrade (stateless reboot). 
+Changing the speed to "inherit" resolves this situation, which is also a best practice.
+
 ## Defect Check Details
 
 ### EP Announce Compatibility
@@ -2648,3 +2657,5 @@ Do not upgrade to any affected ACI software release if this check fails.
 [56]: https://www.cisco.com/c/en/us/td/docs/dcn/whitepapers/cisco-aci-virtual-edge-migration.html
 [57]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwp22212
 [58]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwp15375
+[59]: https://www.cisco.com/c/en/us/td/docs/dcn/aci/apic/5x/basic-configuration/cisco-apic-basic-configuration-guide-52x/m_provisioning.html#Cisco_Task_in_List_GUI.dita_45856d2e-8ddd-41bd-93f7-91207aea2061
+

--- a/tests/host_interface_policy_set_speed_check/fabricHIfPol-pos.json
+++ b/tests/host_interface_policy_set_speed_check/fabricHIfPol-pos.json
@@ -1,0 +1,103 @@
+[
+    {
+        "fabricHIfPol": {
+            "attributes": {
+                "annotation": "orchestrator:msc",
+                "autoNeg": "on",
+                "childAction": "",
+                "creator": "USER",
+                "descr": "",
+                "dfeDelayMs": "0",
+                "dn": "uni/infra/hintfpol-fernandh_interface",
+                "emiRetrain": "disable",
+                "extMngdBy": "",
+                "fecMode": "inherit",
+                "lcOwn": "local",
+                "linkDebounce": "100",
+                "modTs": "2025-05-07T23:54:47.082+00:00",
+                "monPolDn": "uni/fabric/monfab-default",
+                "name": "fernandh_interface",
+                "nameAlias": "",
+                "ownerKey": "",
+                "ownerTag": "",
+                "portPhyMediaType": "auto",
+                "speed": "auto",
+                "status": "",
+                "uid": "0",
+                "userdom": ":all:"
+            },
+            "children": [
+                {
+                    "fabricRtHIfPol": {
+                        "attributes": {
+                            "childAction": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-05-07T23:54:47.082+00:00",
+                            "rn": "rtinfraHIfPol-[uni/infra/funcprof/accportgrp-fernandh_interface]",
+                            "status": "",
+                            "tCl": "infraAccPortGrp",
+                            "tDn": "uni/infra/funcprof/accportgrp-fernandh_interface"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "fabricHIfPol": {
+            "attributes": {
+                "annotation": "",
+                "autoNeg": "on",
+                "childAction": "",
+                "creator": "USER",
+                "descr": "",
+                "dfeDelayMs": "0",
+                "dn": "uni/infra/hintfpol-AUTO",
+                "emiRetrain": "disable",
+                "extMngdBy": "",
+                "fecMode": "inherit",
+                "lcOwn": "local",
+                "linkDebounce": "100",
+                "modTs": "2025-06-03T23:21:03.594+00:00",
+                "monPolDn": "uni/fabric/monfab-default",
+                "name": "AUTO",
+                "nameAlias": "",
+                "ownerKey": "",
+                "ownerTag": "",
+                "portPhyMediaType": "auto",
+                "speed": "auto",
+                "status": "",
+                "uid": "15374",
+                "userdom": ":all:"
+            },
+            "children": [
+                {
+                    "fabricRtHIfPol": {
+                        "attributes": {
+                            "childAction": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-06-03T23:21:07.485+00:00",
+                            "rn": "rtinfraHIfPol-[uni/infra/funcprof/accportgrp-av_accessB]",
+                            "status": "",
+                            "tCl": "infraAccPortGrp",
+                            "tDn": "uni/infra/funcprof/accportgrp-av_accessB"
+                        }
+                    }
+                },
+                {
+                    "fabricRtHIfPol": {
+                        "attributes": {
+                            "childAction": "",
+                            "lcOwn": "local",
+                            "modTs": "2025-06-05T04:53:53.112+00:00",
+                            "rn": "rtinfraHIfPol-[uni/infra/funcprof/accportgrp-av-access]",
+                            "status": "",
+                            "tCl": "infraAccPortGrp",
+                            "tDn": "uni/infra/funcprof/accportgrp-av-access"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/tests/host_interface_policy_set_speed_check/test_host_interface_policy_set_speed_check.py
+++ b/tests/host_interface_policy_set_speed_check/test_host_interface_policy_set_speed_check.py
@@ -1,0 +1,48 @@
+import os
+import pytest
+import logging
+import importlib
+from helpers.utils import read_data
+
+script = importlib.import_module("aci-preupgrade-validation-script")
+
+log = logging.getLogger(__name__)
+dir = os.path.dirname(os.path.abspath(__file__))
+
+
+# icurl queries
+host_interface_policy_api = 'fabricHIfPol.json'
+host_interface_policy_api += '?query-target-filter=and(eq(fabricHIfPol.speed,"auto"))'
+host_interface_policy_api += '&rsp-subtree=children&rsp-subtree-class=fabricRtHIfPol'
+
+@pytest.mark.parametrize( "icurl_outputs, tversion, expected_result",
+    [
+        # MANUAL Cases
+        # No tversion given
+        (
+            {host_interface_policy_api: read_data(dir, "fabricHIfPol-pos.json")},
+            None,
+            script.MANUAL,
+        ),        
+        # FAIL_O Cases
+        # fabricHIfPol with 'auto' speed found
+        (
+            {host_interface_policy_api: read_data(dir, "fabricHIfPol-pos.json")},
+            "6.0(9d)",
+            script.FAIL_O,
+        ),
+        # PASS Cases
+        # No fabricHIfPol with 'auto' speed found
+        (
+            {host_interface_policy_api: []},
+            "6.0(1g)",
+            script.PASS,
+        ),
+    ],
+)
+def test_logic(mock_icurl, tversion, expected_result):
+    tversion = script.AciVersion(tversion) if tversion else None
+    result = script.host_interface_policy_set_speed_check(
+        1, 1, tversion
+    )
+    assert result == expected_result


### PR DESCRIPTION
issue #275 fixed.

lab test, changed from eq=auto to ne=auto , to have test output:


[Check 62/87] Host Interface Policy policy Set...                                                                  FAIL - OUTAGE WARNING!!
  Host Interface Policy                          Set Speed  Policy Groups associated
  ---------------------                          ---------  ------------------------
  uni/infra/hintfpol-100G_test1-49               100G       ar_fec_test
  uni/infra/hintfpol-10gb_fixed                  10G        N/A
  uni/infra/hintfpol-AUTO                        inherit    av-access
  uni/infra/hintfpol-AUTO                        inherit    av_accessB
  uni/infra/hintfpol-EXAMPLE                     40G        PRUEBA
  uni/infra/hintfpol-default                     inherit    1_10
  uni/infra/hintfpol-default                     inherit    1_12
  uni/infra/hintfpol-default                     inherit    698943766
  uni/infra/hintfpol-default                     inherit    698943766-105
  uni/infra/hintfpol-default                     inherit    698943766-106
  uni/infra/hintfpol-default                     inherit    698943766-107
  uni/infra/hintfpol-default                     inherit    AEPFER
  uni/infra/hintfpol-default                     inherit    All_Purpose_PG
  
local pytest:

jeestrad@JEESTRAD-M-L6VV ACI-Pre-Upgrade-Validation-Script % python3 -m pytest tests/host_interface_policy_set_speed_check
======================================================================== test session starts =========================================================================
platform darwin -- Python 3.9.6, pytest-8.2.0, pluggy-1.5.0
rootdir: /Users/jeestrad/Documents/Python/pre-upgrade/ACI-Pre-Upgrade-Validation-Script
configfile: pytest.ini
plugins: anyio-4.8.0
collected 3 items                                                                                                                                                    

tests/host_interface_policy_set_speed_check/test_host_interface_policy_set_speed_check.py::test_logic[icurl_outputs0-None-MANUAL CHECK REQUIRED] 
--------------------------------------------------------------------------- live log setup ---------------------------------------------------------------------------
[17:49:51.554 INFO               initialize:5357] Cleaning up previous run files in preupgrade_validator_logs/
[17:49:51.559 INFO               initialize:5359] Creating directories preupgrade_validator_logs/ and preupgrade_validator_logs/json_results/
PASSED                                                                                                                                                         [ 33%]
tests/host_interface_policy_set_speed_check/test_host_interface_policy_set_speed_check.py::test_logic[icurl_outputs1-6.0(9d)-FAIL - OUTAGE WARNING!!] PASSED   [ 66%]
tests/host_interface_policy_set_speed_check/test_host_interface_policy_set_speed_check.py::test_logic[icurl_outputs2-6.0(1g)-PASS] PASSED                      [100%]

========================================================================= 3 passed in 0.03s ==========================================================================

Fixes #275