### PR TITLE
273 exception handling for `check_wrapper` and `print_result`

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -1226,7 +1226,7 @@ def print_result(title, result, msg='',
         padding += len(title) + CHECK_LEN
     if padding < len(result):
         # when `msg` is too long (ex. unknown exception), `padding` may get shorter
-        # than what it's padding (`result`), or worth get negative.
+        # than what it's padding (`result`), or worse, may get negative.
         # In such a case, keep one whitespace padding even if the full length gets longer.
         padding = len(result) + 1
     output = '{}{:>{}}'.format(msg, result, padding)


### PR DESCRIPTION
* Handle an exception inside the `check_wrapper` decorator but outside of each check.
* Fix a failure in `print_result()` when `msg` is too long.


When `msg` is too long and causes the total length of the output line `[Check XX/YY] <title>... <msg> <result>` to get longer than the maximum length (138), `print_result()` fails with an exception as shown below. The below is an exception example from older APIC version with Python2.7. But the same exception occurs with newer APIC versions with Python3.

```
[Check 28/86] Encap Already In Use (F0467 encap-already-in-use)...                                                                    PASS
[Check 29/86] Access (Untagged) Port Config (F0467 native-or-untagged-encap-failure)... Traceback (most recent call last):
  File "aci-preupgrade-validation-script.py", line 5605, in <module>
    main()
  File "aci-preupgrade-validation-script.py", line 5600, in main
    run_checks(checks, inputs)
  File "aci-preupgrade-validation-script.py", line 5543, in run_checks
    r = check(idx + 1, len(checks), **inputs)
  File "aci-preupgrade-validation-script.py", line 1064, in wrapper
    print_result(title=check_title, **r.as_dict())
  File "aci-preupgrade-validation-script.py", line 1231, in print_result
    output = '{}{:>{}}'.format(msg, result, padding)
ValueError: Sign not allowed in string format specifier
```

Because this exception was happening inside the `check_wrapper` decorator but outside of each check, it slipped the exception handling and caused the entire script to abort. This was fixed by the first item above.
After the first fix with the proper exception handling, the script itself continues to perform remaining checks.

With this change, the last block in the `check_wrapper` decorator was moved inside `finally` to minimize the risk of leaving the result JSON files in the `in-progress` state. As a result, if another exception happens inside `except` again, the error is not displayed in the console output. But it's still visible in the log, and also the summary shows the ERROR count correctly.

The second fix for `print_result()` addresses the exception `Sign not allowed in string format specifier` which can occur when the value of `padding` becomes negative, which can occur when `msg` is too long.
After the second fix, the script can handle long error messages as shown below.

```
[Check 28/86] Encap Already In Use (F0467 encap-already-in-use)...                                                                    PASS
[Check 29/86] Access (Untagged) Port Config (F0467 native-or-untagged-encap-failure)... Unexpected Error: name 'looooooooooooooong_error_message' is not defined ERROR !!
[Check 30/86] BD Subnets (F1425 subnet-overlap)...                                                                                    PASS
```
