### PR TITLE
fix: Add default reason(msg) for `AciResult` for failed checks

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -918,11 +918,11 @@ def is_firstver_gt_secondver(first_ver, second_ver):
 
 class AciResult:
     """
-    APIC uses an object called `AciResult` to store the results of
-    each rule/check in the pre-upgrade validation which is run during the upgrade
+    APIC uses an object called `syntheticMaintPValidate` to store the results of
+    each rule/check in the pre-upgrade validation which runs during the upgrade
     workflow in the APIC GUI. When this script is invoked during the workflow, it
     is expected to write the results of each rule/check to a JSON file (one per rule)
-    in a specific format.
+    in a specific format compliant with `syntheticMaintPValidate`.
     """
     # Expected keys in the JSON file
     __slots__ = (
@@ -992,6 +992,8 @@ class AciResult:
         self.ruleStatus = AciResult.PASS
         if result not in [NA, PASS]:
             self.ruleStatus = AciResult.FAIL
+            if not self.reason:
+                self.reason = "See Failure Details"
             self.failureDetails["failType"] = result
             self.failureDetails["data"] = self.craftData(headers, data)
             if unformatted_headers and unformatted_data:

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -995,6 +995,7 @@ class AciResult:
             if not self.reason:
                 self.reason = "See Failure Details"
             self.failureDetails["failType"] = result
+            self.failureDetails["header"] = headers
             self.failureDetails["data"] = self.craftData(headers, data)
             if unformatted_headers and unformatted_data:
                 self.failureDetails["unformatted_data"] = self.craftData(unformatted_headers, unformatted_data)

--- a/tests/test_run_checks.py
+++ b/tests/test_run_checks.py
@@ -158,12 +158,15 @@ TOTAL                       : 10
                 # reason
                 if result == script.ERROR:
                     assert data["reason"].endswith(err_msg)
-                elif others.get("unformatted_data"):
-                    assert data["reason"] == others.get("msg", "") + (
-                        "\n"
-                        "Parse failure occurred, the provided data may not be complete. "
-                        "Please contact Cisco TAC to identify the missing data."
-                    )
+                elif result not in [script.PASS, script.NA]:
+                    msg = others.get("msg", "See Failure Details")
+                    if others.get("unformatted_data"):
+                        msg += (
+                            "\n"
+                            "Parse failure occurred, the provided data may not be complete. "
+                            "Please contact Cisco TAC to identify the missing data."
+                        )
+                    assert data["reason"] == msg
                 else:
                     assert data["reason"] == others.get("msg", "")
                 # failureDetails.failType


### PR DESCRIPTION
`AciResult` class creates a result of each rule/check in JSON so that the pre-upgrade validation in the APIC GUI can show them., which is planned in 6.2.

`reason` in the `AciResult` output is used in the APIC GUI as a clickable link to open the detailed panel to show the contents of `failureDetails` and such. However, `reason` in this script is mapped to `msg` in `Result` which is typically empty for failed checks. This PR populates "See Failure Details" in `reason` for failed checks when it's empty. If individual checks already populated some strings in `reason`, we use them as is.

```json
{
  "ruleId": "ntp_status_check",
  "name": "NTP Status",
  "description": "",
  "reason": "See Failure Details",    <----
  "sub_reason": "",
  "recommended_action": "Not Synchronized. Check NTP config and NTP server reachability.",
  "docUrl": "https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#ntp-status",
  "severity": "critical",
  "ruleStatus": "failed",
  "showValidation": true,
  "failureDetails": {
    "failType": "FAIL - UPGRADE FAILURE!!",
    "data": [
    --- omit ---
    ],
    "unformatted_data": []
  }
}
```

This PR also adds `header` in `failureDetails` for the future use.

```json
{
  "ruleId": "ntp_status_check",
  "name": "NTP Status",
  "description": "",
  "reason": "See Failure Details",
  "sub_reason": "",
  "recommended_action": "Not Synchronized. Check NTP config and NTP server reachability.",
  "docUrl": "https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#ntp-status",
  "severity": "critical",
  "ruleStatus": "failed",
  "showValidation": true,
  "failureDetails": {
    "failType": "FAIL - UPGRADE FAILURE!!",
    "header": ["Pod-ID", "Node-ID"],    <---
    "data": [
    --- omit ---
    ],
    "unformatted_data": []
  }
}
```