### PR TITLE
New Validation for cfd CSCwr08802

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -6007,6 +6007,49 @@ def apic_vmm_inventory_sync_faults_check(**kwargs):
         recommended_action=recommended_action,
         doc_url=doc_url)
 
+
+@check_wrapper(check_title='SSD Firmware Version Check')
+def ssd_firmware_version_check(tversion, **kwargs):
+    result = PASS
+    headers = ["Node_ID","SSD model", "Firmware version"]
+    data = []
+
+    recommended_action = 'Contact Cisco TAC to upgrade SSD firmware to an unaffected version'
+    doc_url = 'https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#ssd-firmware-version-check'
+
+    if not tversion:
+        return Result(result=MANUAL, msg=TVER_MISSING)
+
+    if tversion.older_than("6.1(5h)"):
+
+        eqptFlash_api = 'eqptFlash.json'
+        ssd_details = icurl('class', eqptFlash_api)
+        if not ssd_details:
+            return Result(result=FAIL_UF, msg="No eqptFlash object found in the system. Cannot validate SSD firmware versions.", doc_url=doc_url)
+        
+        models_to_check = ['Micron_5400', 'Micron_5300', 'Micron_5100']
+        version_to_check = ['D0MU078', 'D3CN003', 'D3MU005', 'D4CN005']
+       
+        for ssd_data in ssd_details:
+            node_dn = ssd_data['eqptFlash']['attributes']['dn']
+            model = ssd_data['eqptFlash']['attributes']['model']
+            firmware_version = ssd_data['eqptFlash']['attributes']['rev']
+            
+            node_match = re.search(r"node-(?P<node>\d+)", node_dn)
+            node_id = node_match.group('node')
+
+            if any(m in model for m in models_to_check):
+                if any(firmware_version.startswith(v[:4]) and firmware_version < v for v in version_to_check):
+                    data.append([node_id, model, firmware_version])
+    else:
+        return Result(result=NA, msg=VER_NOT_AFFECTED)
+
+    if data:
+        result = FAIL_O
+
+    return Result(result=result, headers=headers, data=data, recommended_action=recommended_action, doc_url=doc_url)
+
+
 # ---- Script Execution ----
 
 
@@ -6168,6 +6211,7 @@ class CheckManager:
         standby_sup_sync_check,
         isis_database_byte_check,
         configpush_shard_check,
+        ssd_firmware_version_check,
 
     ]
     ssh_checks = [

--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -191,6 +191,7 @@ Items                                           | Defect       | This Script    
 [Stale pconsRA Object][d26]                     | CSCwp22212   | :warning:{title="Deprecated"} | :no_entry_sign:
 [ISIS DTEPs Byte Size][d27]                     | CSCwp15375   | :white_check_mark: | :no_entry_sign:
 [Policydist configpushShardCont Crash][d28]     | CSCwp95515   | :white_check_mark: | 
+[ssd_firmware_version_check][d29]               | CSCwr08802   | :white_check_mark: | :no_entry_sign:
 
 [d1]: #ep-announce-compatibility
 [d2]: #eventmgr-db-size-defect-susceptibility
@@ -220,6 +221,7 @@ Items                                           | Defect       | This Script    
 [d26]: #stale-pconsra-object
 [d27]: #isis-dteps-byte-size
 [d28]: #policydist-configpushshardcont-crash
+[d29]: #ssd-firmware-version-check
 
 
 ## General Check Details
@@ -2613,6 +2615,21 @@ Due to [CSCwp95515][59], upgrading to an affected version while having any `conf
 
 If any instances of `configpushShardCont` are flagged by this script, Cisco TAC must be contacted to identify and resolve the underlying issue before performing the upgrade.
 
+### ssd firmware version check
+
+RCA:
+
+if Switch SSD model is identifed as Micron 5100 or 5300 or 5400 and SSD firmware version is lower than the(D0MU078, D3CN003, D3MU005. and D4CN005),  firmware upgrade is required to mitigate the core exception issue.
+
+Impact:
+
+Due to [CSCwr08802][62],  Switch reloads due to a hap-reset with no core file collected by sysmgr from the time of the crash. Usually this is seen with processes epm or epmc however other processes may also be affected.
+
+Suggestion:
+
+This check will identify the affected SSD firmware and alert if the affected version is detected.
+Cisco TAC must be contacted to Upgrade identified SSD firmware for the fixed.
+
 
 [0]: https://github.com/datacenter/ACI-Pre-Upgrade-Validation-Script
 [1]: https://www.cisco.com/c/dam/en/us/td/docs/Website/datacenter/apicmatrix/index.html
@@ -2676,3 +2693,5 @@ If any instances of `configpushShardCont` are flagged by this script, Cisco TAC 
 [59]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwp95515
 [60]: https://www.cisco.com/c/en/us/solutions/collateral/data-center-virtualization/application-centric-infrastructure/white-paper-c11-743951.html#Inter
 [61]: https://www.cisco.com/c/en/us/solutions/collateral/data-center-virtualization/application-centric-infrastructure/white-paper-c11-743951.html#EnablePolicyCompression
+[62]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwr08802
+

--- a/tests/checks/ssd_firmware_version_check/eqptFlash_affected_models.json
+++ b/tests/checks/ssd_firmware_version_check/eqptFlash_affected_models.json
@@ -1,0 +1,53 @@
+ [
+        {
+            "eqptFlash": {
+                "attributes": {
+                    "dn": "topology/pod-1/node-1104/sys/ch/supslot-1/sup/flash",
+                    "model": "Micron_5100_MTFDDAV240TCB",
+                    "rev": "D0MU073",
+                    "ser": "PHYH2515051U240J"
+                }
+            }
+        },
+        {
+            "eqptFlash": {
+                "attributes": {
+                    "dn": "topology/pod-1/node-1105/sys/ch/supslot-1/sup/flash",
+                    "model": "Micron_5400_MTFDDAV240TGA",
+                    "rev": "D4CN001",
+                    "ser": "BTYH2262071T240J"
+                   
+                }
+            }
+        },
+        {
+            "eqptFlash": {
+                "attributes": {
+                    "dn": "topology/pod-1/node-1102/sys/ch/supslot-1/sup/flash",
+                    "model": "Micron_5300_MTFDDAV240TGA",
+                    "rev": "D3CN002",
+                    "ser": "PHYH251504SK240J"
+                }
+            }
+        },
+         {
+            "eqptFlash": {
+                "attributes": {
+                    "dn": "topology/pod-1/node-1102/sys/ch/supslot-1/sup/flash",
+                    "model": "Micron_5300_MTFDDAV240TGA",
+                    "rev": "D3MU004",
+                    "ser": "PHYH251504SK240J"
+                }
+            }
+        },
+        {
+            "eqptFlash": {
+                "attributes": {
+                    "dn": "topology/pod-1/node-1101/sys/ch/supslot-1/sup/flash",
+                    "model": "SSDSCKKB240G8K",
+                    "rev": "XC311132",
+                    "ser": "PHYH239002C0240J"
+                }
+            }
+        }
+]

--- a/tests/checks/ssd_firmware_version_check/eqptFlash_unaffected_models.json
+++ b/tests/checks/ssd_firmware_version_check/eqptFlash_unaffected_models.json
@@ -1,0 +1,49 @@
+ [
+        {
+            "eqptFlash": {
+                "attributes": {
+                   
+                    "dn": "topology/pod-1/node-1104/sys/ch/supslot-1/sup/flash",
+                    "model": "SSDSCKKB240G8K",
+                    "rev": "XC311132"
+                }
+            }
+        },
+        {
+            "eqptFlash": {
+                "attributes": {
+                    "dn": "topology/pod-1/node-1105/sys/ch/supslot-1/sup/flash",
+                    "model": "SSDSCKKB240G8K",
+                    "rev": "XC311132"
+                }
+            }
+        },
+        {
+            "eqptFlash": {
+                "attributes": {
+                    "dn": "topology/pod-1/node-1102/sys/ch/supslot-1/sup/flash",
+                    "model": "SSDSCKKB240G8K",
+                    "rev": "XC311132"
+                }
+            }
+        },
+        {
+            "eqptFlash": {
+                "attributes": {
+                    "dn": "topology/pod-1/node-1103/sys/ch/supslot-1/sup/flash",
+                    "model": "SSDSCKKB240G8K",
+                    "rev": "XC311132"
+                   
+                }
+            }
+        },
+        {
+            "eqptFlash": {
+                "attributes": {
+                    "dn": "topology/pod-2/node-1109/sys/ch/supslot-1/sup/flash",
+                    "model": "SSDSCKKB240G8K",
+                    "rev": "XC311132"
+                }
+            }
+        }
+]

--- a/tests/checks/ssd_firmware_version_check/test_ssd_firmware_version_check.py
+++ b/tests/checks/ssd_firmware_version_check/test_ssd_firmware_version_check.py
@@ -1,0 +1,61 @@
+import os
+import pytest
+import logging
+import importlib
+from helpers.utils import read_data
+
+script = importlib.import_module("aci-preupgrade-validation-script")
+
+log = logging.getLogger(__name__)
+dir = os.path.dirname(os.path.abspath(__file__))
+
+test_function = "ssd_firmware_version_check"
+
+# icurl queries
+eqptFlash_api = 'eqptFlash.json'
+
+
+@pytest.mark.parametrize(
+    "icurl_outputs, tversion, expected_result",
+    [
+        # TVERSION not supplied
+        (
+            {eqptFlash_api: read_data(dir, "eqptFlash_unaffected_models.json")},
+            None,
+            script.MANUAL,
+        ),
+
+        # No eqptFlash objects
+        (
+            {eqptFlash_api: []},
+            "5.2(5e)",
+            script.FAIL_UF,
+        ),
+
+        # eqptFlash objects present, going to affected apic version and affected firmware models
+        (
+            {eqptFlash_api: read_data(dir, "eqptFlash_affected_models.json")},
+            "5.2(6a)",
+            script.FAIL_O,
+        ),
+
+        # eqptFlash objects present, going to affected apic version and unaffected firmware models
+        (
+            {eqptFlash_api: read_data(dir, "eqptFlash_unaffected_models.json")},
+            "5.2(6a)",
+            script.PASS,
+        ),
+        
+        # Fixed Target Version
+        (
+            {eqptFlash_api: read_data(dir, "eqptFlash_unaffected_models.json")},
+            "6.2(1a)",
+            script.NA,
+        ),
+    ],
+)
+def test_logic(run_check, mock_icurl, tversion, expected_result):
+    result = run_check(
+        tversion=script.AciVersion(tversion) if tversion else None,
+    )
+    assert result.result == expected_result


### PR DESCRIPTION

Added Validation for cfd CSCwr08802.

Pass log:

 python aci-preupgrade-validation-script.py --tversion "6.1(3f)" -d "ssd_firmware_version_check"
    ==== 2026-01-09T13-08-15+0000, Script Version v4.0.1  ====

!!!! Check https://github.com/datacenter/ACI-Pre-Upgrade-Validation-Script for Latest Release !!!!

To use a non-default Login Domain, enter apic#DOMAIN\\USERNAME
Enter username for APIC login          : admin
Enter password for corresponding User  :

Gathering Node Information...

Current APIC Version...6.0(9e)
Lowest Switch Version...4.2(3j)

Target APIC version is overridden to 6.1(3f)

Collecting VPC Node IDs...101, 103

Progress: |----------------------------------------------------------------------------------------------------| 0/1 checkProgress: |████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 checks completed


=== Check Result (failed only) ===


=== Summary Result ===

PASS                        :  1
FAIL - OUTAGE WARNING!!     :  0
FAIL - UPGRADE FAILURE!!    :  0
MANUAL CHECK REQUIRED       :  0
POST UPGRADE CHECK REQUIRED :  0
N/A                         :  0
ERROR !!                    :  0
TOTAL                       :  1

    Pre-Upgrade Check Complete.
    Next Steps: Address all checks flagged as FAIL, ERROR or MANUAL CHECK REQUIRED

    Result output and debug info saved to below bundle for later reference.
    Attach this bundle to Cisco TAC SRs opened to address the flagged checks.

      Result Bundle: /data/techsupport/preupgrade_validator_2026-01-09T13-08-15+0000.tgz

==== Script Version v4.0.1 FIN ====

Pytest log:

================================================== test session starts ===================================================
platform linux -- Python 3.8.10, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /data/ssd/muthuku/PreCFDAutomation/ACI-Pre-Upgrade-Validation-Script
configfile: pytest.ini
collected 5 items

ssd_firmware_version_check/test_ssd_firmware_version_check.py::test_logic[icurl_outputs0-None-MANUAL CHECK REQUIRED]
----------------------------------------------------- live log setup -----------------------------------------------------
[13:06:35.892 INFO     init_system:6076(MainThread)] Cleaning up previous run files in preupgrade_validator_logs/
[13:06:35.893 INFO     init_system:6078(MainThread)] Creating directories preupgrade_validator_logs/ and preupgrade_validator_logs/json_results/
----------------------------------------------------- live log call ------------------------------------------------------
[13:06:35.894 INFO     init_result:1182(MainThread)] Initialized in preupgrade_validator_logs/json_results/ssd_firmware_version_check.json
[13:06:35.895 INFO     _start_thread:1105(MainThread)] (ssd_firmware_version_check) Starting thread.
[13:06:35.896 INFO     wrapper:1349(ssd_firmware_version_check)] Start ssd_firmware_version_check
Progress: |----------------------------------------------------------------------------------------------------| 0/1 check[13:06:35.898 INFO     update_result:1191(ssd_firmware_version_check)] Finalized result in preupgrade_validator_logs/json_results/ssd_firmware_version_check.json
Progress: |████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 checkPASSEDleted
ssd_firmware_version_check/test_ssd_firmware_version_check.py::test_logic[icurl_outputs1-5.2(5e)-FAIL - UPGRADE FAILURE!!]
----------------------------------------------------- live log call ------------------------------------------------------
[13:06:35.913 INFO     init_result:1182(MainThread)] Initialized in preupgrade_validator_logs/json_results/ssd_firmware_version_check.json
[13:06:35.914 INFO     _start_thread:1105(MainThread)] (ssd_firmware_version_check) Starting thread.
[13:06:35.914 INFO     wrapper:1349(ssd_firmware_version_check)] Start ssd_firmware_version_check
[13:06:35.915 INFO     update_result:1191(ssd_firmware_version_check)] Finalized result in preupgrade_validator_logs/json_results/ssd_firmware_version_check.json
Progress: |----------------------------------------------------------------------------------------------------| 0/1 checkProgress: |████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 checkPASSEDleted
ssd_firmware_version_check/test_ssd_firmware_version_check.py::test_logic[icurl_outputs2-5.2(6a)-FAIL - OUTAGE WARNING!!]
----------------------------------------------------- live log call ------------------------------------------------------
[13:06:35.929 INFO     init_result:1182(MainThread)] Initialized in preupgrade_validator_logs/json_results/ssd_firmware_version_check.json
[13:06:35.930 INFO     _start_thread:1105(MainThread)] (ssd_firmware_version_check) Starting thread.
[13:06:35.931 INFO     wrapper:1349(ssd_firmware_version_check)] Start ssd_firmware_version_check
Progress: |----------------------------------------------------------------------------------------------------| 0/1 check[13:06:35.933 INFO     update_result:1191(ssd_firmware_version_check)] Finalized result in preupgrade_validator_logs/json_results/ssd_firmware_version_check.json
Progress: |████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 checkPASSEDleted
ssd_firmware_version_check/test_ssd_firmware_version_check.py::test_logic[icurl_outputs3-5.2(6a)-PASS]
----------------------------------------------------- live log call ------------------------------------------------------
[13:06:35.945 INFO     init_result:1182(MainThread)] Initialized in preupgrade_validator_logs/json_results/ssd_firmware_version_check.json
[13:06:35.946 INFO     _start_thread:1105(MainThread)] (ssd_firmware_version_check) Starting thread.
[13:06:35.946 INFO     wrapper:1349(ssd_firmware_version_check)] Start ssd_firmware_version_check
Progress: |----------------------------------------------------------------------------------------------------| 0/1 check[13:06:35.947 INFO     update_result:1191(ssd_firmware_version_check)] Finalized result in preupgrade_validator_logs/json_results/ssd_firmware_version_check.json
Progress: |████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 checkPASSEDleted
ssd_firmware_version_check/test_ssd_firmware_version_check.py::test_logic[icurl_outputs4-6.2(1a)-N/A]
----------------------------------------------------- live log call ------------------------------------------------------
[13:06:35.960 INFO     init_result:1182(MainThread)] Initialized in preupgrade_validator_logs/json_results/ssd_firmware_version_check.json
[13:06:35.961 INFO     _start_thread:1105(MainThread)] (ssd_firmware_version_check) Starting thread.
[13:06:35.961 INFO     wrapper:1349(ssd_firmware_version_check)] Start ssd_firmware_version_check
[13:06:35.962 INFO     update_result:1191(ssd_firmware_version_check)] Finalized result in preupgrade_validator_logs/json_results/ssd_firmware_version_check.json
Progress: |----------------------------------------------------------------------------------------------------| 0/1 checkProgress: |████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 checkPASSEDleted

=================================================== 5 passed in 0.12s ====================================================