### PR TITLE
New Validation against CSCwr08802

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
@@ -159,6 +159,9 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# VS Code
+.vscode/
 
 # project specific files
 preupgrade_validator_logs/

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -6025,6 +6025,100 @@ def apic_downgrade_compat_warning_check(cversion, tversion, **kwargs):
 
     return Result(result=result, headers=headers, data=data, recommended_action=recommended_action, doc_url=doc_url)
 
+@check_wrapper(check_title='Switch SSD firmware version on Micron M5100/M5300/M5400 models')
+def switch_micron_ssd_firmware_check(tversion, **kwargs):
+    # Conditions of this check for failure scenario:
+    # 1. The target version is lower than 6.1(5e)
+    # 2. Switch SSD model is Micron 5100 or 5300 or 5400 
+    # 3. SSD firmware version is lower than D0MU078, D3CN003, D3MU005, and D4CN005
+    # If all above conditions are met, CSCwr08802 (Switch reloads due to a hap-reset on switches 
+    # running Micron M5100/M5300/M5400) may occur after APIC upgrade.
+    # Take either of the below actions to resolve the issue:
+    # 1. Contact Cisco TAC to upgrade the SSD firmware manually
+    # 2. Upgrade the APIC to at least 6.1(5e) where the issue is fixed.
+
+    def compare_ssd_firmware_versions(current, required):
+        """
+        Compare firmware versions by checking last 3 digits
+        Returns True if upgrade is required (current < required)
+        """
+        try:
+            current_ver = int(current[-3:])
+            required_ver = int(required[-3:])
+            return current_ver < required_ver
+        except (ValueError, IndexError) as e:
+            log.error("Failed to compare versions {} vs {}: {}".format(current, required, e))
+            return False
+
+    M5100_REQ_FW_VER = "D0MU078"
+    M5300_D3CN_REQ_FW_VER = "D3CN003"
+    M5300_D3MU_REQ_FW_VER = "D3MU005"
+    M5400_REQ_FW_VER = "D4CN005"
+
+    result = PASS
+    headers = ["Node ID", "SSD Model", "SSD Firmware Version"]
+    data = []
+    recommended_action = ''
+    doc_url = 'https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#ssds-going-into-read-only-mode'
+
+    if not tversion:
+        return Result(result=MANUAL, msg=TVER_MISSING)
+    
+    if tversion.newer_than("6.1(5e)") or tversion.same_as("6.1(5e)"):
+        return Result(result=NA, msg=VER_NOT_AFFECTED)
+
+    eqptFlash = icurl('class', 
+                      'eqptFlash.json?query-target-filter=or(wcard(eqptFlash.model,"Micron_5300*"),wcard(eqptFlash.model,"Micron_5100*"),wcard(eqptFlash.model,"Micron_5400*"))')
+    
+    for flash in eqptFlash:
+        attrs = flash['eqptFlash']['attributes']
+        dn = attrs.get('dn', '')
+        model = attrs.get('model', '')
+        rev = attrs.get('rev', '')
+        
+        # Extract node ID from DN
+        node_match = re.search(node_regex, dn)
+        if not node_match:
+            log.debug("Could not extract node ID from DN: {}".format(dn))
+            continue
+        node_id = node_match.group("node")
+        
+        # Check M5100 firmware version
+        if "Micron_5100" in model:
+            if compare_ssd_firmware_versions(rev, M5100_REQ_FW_VER):
+                data.append([node_id, model, rev])
+        
+        # Check M5300 firmware version (two variants: D3CN and D3MU)
+        elif "Micron_5300" in model:
+            if len(rev) >= 4:
+                ssd_fw_prefix = rev[:4]
+                if ssd_fw_prefix == "D3CN":
+                    if compare_ssd_firmware_versions(rev, M5300_D3CN_REQ_FW_VER):
+                        data.append([node_id, model, rev])
+                elif ssd_fw_prefix == "D3MU":
+                    if compare_ssd_firmware_versions(rev, M5300_D3MU_REQ_FW_VER):
+                        data.append([node_id, model, rev])
+        
+        # Check M5400 firmware version
+        elif "Micron_5400" in model:
+            if compare_ssd_firmware_versions(rev, M5400_REQ_FW_VER):
+                data.append([node_id, model, rev])
+    
+    if data:
+        result = FAIL_O
+        recommended_action = (
+            "\n\tTo avoid potential switch reloads due to a hap-reset after the APIC upgrade, "
+            "contact Cisco TAC to upgrade the SSD firmware on the affected switches to at least "
+            "the required versions:\n"
+            "\t - Micron M5100: {}\n"
+            "\t - Micron M5300 (D3CN): {}\n"
+            "\t - Micron M5300 (D3MU): {}\n"
+            "\t - Micron M5400: {}\n"
+            "\tAlternatively, consider upgrading the ACI switches to at least version 16.1(5e) where this issue is resolved."
+        ).format(M5100_REQ_FW_VER, M5300_D3CN_REQ_FW_VER, M5300_D3MU_REQ_FW_VER, M5400_REQ_FW_VER)
+    
+    return Result(result=result, headers=headers, data=data, 
+                  recommended_action=recommended_action, doc_url=doc_url)
 
 # ---- Script Execution ----
 
@@ -6188,6 +6282,7 @@ class CheckManager:
         standby_sup_sync_check,
         isis_database_byte_check,
         configpush_shard_check,
+        switch_micron_ssd_firmware_check,
 
     ]
     ssh_checks = [

--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -193,6 +193,7 @@ Items                                           | Defect       | This Script    
 [Stale pconsRA Object][d26]                     | CSCwp22212   | :warning:{title="Deprecated"} | :no_entry_sign:
 [ISIS DTEPs Byte Size][d27]                     | CSCwp15375   | :white_check_mark: | :no_entry_sign:
 [Policydist configpushShardCont Crash][d28]     | CSCwp95515   | :white_check_mark: | 
+[SSDs going into Read-Only Mode][d29]          | CSCwr08802   | :white_check_mark: | :no_entry_sign:
 
 [d1]: #ep-announce-compatibility
 [d2]: #eventmgr-db-size-defect-susceptibility
@@ -222,6 +223,7 @@ Items                                           | Defect       | This Script    
 [d26]: #stale-pconsra-object
 [d27]: #isis-dteps-byte-size
 [d28]: #policydist-configpushshardcont-crash
+[d29]: #ssds-going-into-read-only-mode
 
 
 ## General Check Details
@@ -2647,6 +2649,12 @@ Due to [CSCwp95515][59], upgrading to an affected version while having any `conf
 
 If any instances of `configpushShardCont` are flagged by this script, Cisco TAC must be contacted to identify and resolve the underlying issue before performing the upgrade.
 
+### SSDs going into read-only mode
+
+Due to [CSCwr08802][62], Nexus 9000 series switches with Micron `M5100, M5300 and M5400` series SSDs are susceptible to SSDs going into Read Only mode. The SSDs may incorrectly trigger their internal power hold-up circuit. This causes the drive to enter a protective "write-protect" (Read-Only) mode to prevent potential data loss. When the SSD becomes read-only, processes may crash (causing a hap-reset), or the device may become unresponsive. 
+
+The script checks if any Nexus 9000 series switches in the fabric are using Micron `M5100, M5300 and M5400` series SSDs with affected firmware versions. If so, to mitigate the risk of SSDs going into read-only mode, contact Cisco TAC to arrange for SSD firmware manual upgrade, or upgrade ACI switch software to 16.1(5) or later maintenance release which includes automated SSD firmware upgrade process.
+
 
 [0]: https://github.com/datacenter/ACI-Pre-Upgrade-Validation-Script
 [1]: https://www.cisco.com/c/dam/en/us/td/docs/Website/datacenter/apicmatrix/index.html
@@ -2710,3 +2718,4 @@ If any instances of `configpushShardCont` are flagged by this script, Cisco TAC 
 [59]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwp95515
 [60]: https://www.cisco.com/c/en/us/solutions/collateral/data-center-virtualization/application-centric-infrastructure/white-paper-c11-743951.html#Inter
 [61]: https://www.cisco.com/c/en/us/solutions/collateral/data-center-virtualization/application-centric-infrastructure/white-paper-c11-743951.html#EnablePolicyCompression
+[62]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwr08802

--- a/tests/checks/switch_micron_ssd_firmware_check/eqptFlash_m5100_outdated.json
+++ b/tests/checks/switch_micron_ssd_firmware_check/eqptFlash_m5100_outdated.json
@@ -1,0 +1,38 @@
+{
+  "totalCount": "1",
+  "imdata": [
+    {
+      "eqptFlash": {
+        "attributes": {
+          "acc": "read-write",
+          "cap": "244198",
+          "childAction": "",
+          "deltape": "0",
+          "descr": "flash",
+          "dn": "topology/pod-1/node-101/sys/ch/supslot-1/sup/flash",
+          "gbb": "0",
+          "id": "1",
+          "lba": "0",
+          "lifetime": "5",
+          "majorAlarm": "no",
+          "mfgTm": "2026-01-10T09:20:30.123+00:00",
+          "minorAlarm": "no",
+          "modTs": "2026-02-10T09:19:45.456+00:00",
+          "model": "Micron_5100_MTFDDAK256TBN",
+          "monPolDn": "uni/fabric/monfab-default",
+          "operSt": "ok",
+          "peCycles": "250",
+          "readErr": "0",
+          "rev": "D0MU070",
+          "ser": "MSA23440123",
+          "status": "",
+          "tbw": "25.678901",
+          "type": "flash",
+          "vendor": "Micron",
+          "warning": "no",
+          "wlc": "0"
+        }
+      }
+    }
+  ]
+}

--- a/tests/checks/switch_micron_ssd_firmware_check/eqptFlash_m5300_d3cn_outdated.json
+++ b/tests/checks/switch_micron_ssd_firmware_check/eqptFlash_m5300_d3cn_outdated.json
@@ -1,0 +1,38 @@
+{
+  "totalCount": "1",
+  "imdata": [
+    {
+      "eqptFlash": {
+        "attributes": {
+          "acc": "read-write",
+          "cap": "457862",
+          "childAction": "",
+          "deltape": "0",
+          "descr": "flash",
+          "dn": "topology/pod-1/node-102/sys/ch/supslot-1/sup/flash",
+          "gbb": "0",
+          "id": "1",
+          "lba": "0",
+          "lifetime": "4",
+          "majorAlarm": "no",
+          "mfgTm": "2026-01-12T11:35:45.234+00:00",
+          "minorAlarm": "no",
+          "modTs": "2026-02-10T11:35:00.567+00:00",
+          "model": "Micron_5300_MTFDDAK480TDS",
+          "monPolDn": "uni/fabric/monfab-default",
+          "operSt": "ok",
+          "peCycles": "180",
+          "readErr": "0",
+          "rev": "D3CN001",
+          "ser": "MSA23440456",
+          "status": "",
+          "tbw": "18.234567",
+          "type": "flash",
+          "vendor": "Micron",
+          "warning": "no",
+          "wlc": "0"
+        }
+      }
+    }
+  ]
+}

--- a/tests/checks/switch_micron_ssd_firmware_check/eqptFlash_m5300_d3mu_outdated.json
+++ b/tests/checks/switch_micron_ssd_firmware_check/eqptFlash_m5300_d3mu_outdated.json
@@ -1,0 +1,38 @@
+{
+  "totalCount": "1",
+  "imdata": [
+    {
+      "eqptFlash": {
+        "attributes": {
+          "acc": "read-write",
+          "cap": "915724",
+          "childAction": "",
+          "deltape": "0",
+          "descr": "flash",
+          "dn": "topology/pod-1/node-103/sys/ch/supslot-1/sup/flash",
+          "gbb": "0",
+          "id": "1",
+          "lba": "0",
+          "lifetime": "6",
+          "majorAlarm": "no",
+          "mfgTm": "2026-01-08T15:50:20.345+00:00",
+          "minorAlarm": "no",
+          "modTs": "2026-02-10T15:49:35.678+00:00",
+          "model": "Micron_5300_MTFDDAK960TDS",
+          "monPolDn": "uni/fabric/monfab-default",
+          "operSt": "ok",
+          "peCycles": "320",
+          "readErr": "0",
+          "rev": "D3MU003",
+          "ser": "MSA23440789",
+          "status": "",
+          "tbw": "32.345678",
+          "type": "flash",
+          "vendor": "Micron",
+          "warning": "no",
+          "wlc": "0"
+        }
+      }
+    }
+  ]
+}

--- a/tests/checks/switch_micron_ssd_firmware_check/eqptFlash_m5400_outdated.json
+++ b/tests/checks/switch_micron_ssd_firmware_check/eqptFlash_m5400_outdated.json
@@ -1,0 +1,38 @@
+{
+  "totalCount": "1",
+  "imdata": [
+    {
+      "eqptFlash": {
+        "attributes": {
+          "acc": "read-write",
+          "cap": "1831448",
+          "childAction": "",
+          "deltape": "0",
+          "descr": "flash",
+          "dn": "topology/pod-1/node-104/sys/ch/supslot-1/sup/flash",
+          "gbb": "0",
+          "id": "1",
+          "lba": "0",
+          "lifetime": "3",
+          "majorAlarm": "no",
+          "mfgTm": "2026-01-18T13:25:55.456+00:00",
+          "minorAlarm": "no",
+          "modTs": "2026-02-10T13:25:10.789+00:00",
+          "model": "Micron_5400_MTFDDAK1T9TGP",
+          "monPolDn": "uni/fabric/monfab-default",
+          "operSt": "ok",
+          "peCycles": "145",
+          "readErr": "0",
+          "rev": "D4CN003",
+          "ser": "MSA23441012",
+          "status": "",
+          "tbw": "14.567890",
+          "type": "flash",
+          "vendor": "Micron",
+          "warning": "no",
+          "wlc": "0"
+        }
+      }
+    }
+  ]
+}

--- a/tests/checks/switch_micron_ssd_firmware_check/eqptFlash_multiple_outdated.json
+++ b/tests/checks/switch_micron_ssd_firmware_check/eqptFlash_multiple_outdated.json
@@ -1,0 +1,104 @@
+{
+  "totalCount": "3",
+  "imdata": [
+    {
+      "eqptFlash": {
+        "attributes": {
+          "acc": "read-write",
+          "cap": "244198",
+          "childAction": "",
+          "deltape": "0",
+          "descr": "flash",
+          "dn": "topology/pod-1/node-101/sys/ch/supslot-1/sup/flash",
+          "gbb": "0",
+          "id": "1",
+          "lba": "0",
+          "lifetime": "5",
+          "majorAlarm": "no",
+          "mfgTm": "2026-01-10T09:20:30.123+00:00",
+          "minorAlarm": "no",
+          "modTs": "2026-02-10T09:19:45.456+00:00",
+          "model": "Micron_5100_MTFDDAK256TBN",
+          "monPolDn": "uni/fabric/monfab-default",
+          "operSt": "ok",
+          "peCycles": "250",
+          "readErr": "0",
+          "rev": "D0MU070",
+          "ser": "MSA23440123",
+          "status": "",
+          "tbw": "25.678901",
+          "type": "flash",
+          "vendor": "Micron",
+          "warning": "no",
+          "wlc": "0"
+        }
+      }
+    },
+    {
+      "eqptFlash": {
+        "attributes": {
+          "acc": "read-write",
+          "cap": "457862",
+          "childAction": "",
+          "deltape": "0",
+          "descr": "flash",
+          "dn": "topology/pod-1/node-102/sys/ch/supslot-1/sup/flash",
+          "gbb": "0",
+          "id": "1",
+          "lba": "0",
+          "lifetime": "4",
+          "majorAlarm": "no",
+          "mfgTm": "2026-01-12T11:35:45.234+00:00",
+          "minorAlarm": "no",
+          "modTs": "2026-02-10T11:35:00.567+00:00",
+          "model": "Micron_5300_MTFDDAK480TDS",
+          "monPolDn": "uni/fabric/monfab-default",
+          "operSt": "ok",
+          "peCycles": "180",
+          "readErr": "0",
+          "rev": "D3CN001",
+          "ser": "MSA23440456",
+          "status": "",
+          "tbw": "18.234567",
+          "type": "flash",
+          "vendor": "Micron",
+          "warning": "no",
+          "wlc": "0"
+        }
+      }
+    },
+    {
+      "eqptFlash": {
+        "attributes": {
+          "acc": "read-write",
+          "cap": "1831448",
+          "childAction": "",
+          "deltape": "0",
+          "descr": "flash",
+          "dn": "topology/pod-1/node-104/sys/ch/supslot-1/sup/flash",
+          "gbb": "0",
+          "id": "1",
+          "lba": "0",
+          "lifetime": "3",
+          "majorAlarm": "no",
+          "mfgTm": "2026-01-18T13:25:55.456+00:00",
+          "minorAlarm": "no",
+          "modTs": "2026-02-10T13:25:10.789+00:00",
+          "model": "Micron_5400_MTFDDAK1T9TGP",
+          "monPolDn": "uni/fabric/monfab-default",
+          "operSt": "ok",
+          "peCycles": "145",
+          "readErr": "0",
+          "rev": "D4CN003",
+          "ser": "MSA23441012",
+          "status": "",
+          "tbw": "14.567890",
+          "type": "flash",
+          "vendor": "Micron",
+          "warning": "no",
+          "wlc": "0"
+        }
+      }
+    }
+  ]
+}

--- a/tests/checks/switch_micron_ssd_firmware_check/eqptFlash_pass.json
+++ b/tests/checks/switch_micron_ssd_firmware_check/eqptFlash_pass.json
@@ -1,0 +1,137 @@
+{
+  "totalCount": "4",
+  "imdata": [
+    {
+      "eqptFlash": {
+        "attributes": {
+          "acc": "read-write",
+          "cap": "244198",
+          "childAction": "",
+          "deltape": "0",
+          "descr": "flash",
+          "dn": "topology/pod-1/node-101/sys/ch/supslot-1/sup/flash",
+          "gbb": "0",
+          "id": "1",
+          "lba": "0",
+          "lifetime": "3",
+          "majorAlarm": "no",
+          "mfgTm": "2026-01-15T10:30:15.123+00:00",
+          "minorAlarm": "no",
+          "modTs": "2026-02-10T10:29:30.456+00:00",
+          "model": "Micron_5100_MTFDDAK256TBN",
+          "monPolDn": "uni/fabric/monfab-default",
+          "operSt": "ok",
+          "peCycles": "120",
+          "readErr": "0",
+          "rev": "D0MU080",
+          "ser": "MSA23450123",
+          "status": "",
+          "tbw": "15.234567",
+          "type": "flash",
+          "vendor": "Micron",
+          "warning": "no",
+          "wlc": "0"
+        }
+      }
+    },
+    {
+      "eqptFlash": {
+        "attributes": {
+          "acc": "read-write",
+          "cap": "457862",
+          "childAction": "",
+          "deltape": "0",
+          "descr": "flash",
+          "dn": "topology/pod-1/node-102/sys/ch/supslot-1/sup/flash",
+          "gbb": "0",
+          "id": "1",
+          "lba": "0",
+          "lifetime": "2",
+          "majorAlarm": "no",
+          "mfgTm": "2026-01-20T08:15:22.789+00:00",
+          "minorAlarm": "no",
+          "modTs": "2026-02-10T08:14:45.321+00:00",
+          "model": "Micron_5300_MTFDDAK480TDS",
+          "monPolDn": "uni/fabric/monfab-default",
+          "operSt": "ok",
+          "peCycles": "85",
+          "readErr": "0",
+          "rev": "D3CN005",
+          "ser": "MSA23450456",
+          "status": "",
+          "tbw": "12.456789",
+          "type": "flash",
+          "vendor": "Micron",
+          "warning": "no",
+          "wlc": "0"
+        }
+      }
+    },
+    {
+      "eqptFlash": {
+        "attributes": {
+          "acc": "read-write",
+          "cap": "915724",
+          "childAction": "",
+          "deltape": "0",
+          "descr": "flash",
+          "dn": "topology/pod-1/node-103/sys/ch/supslot-1/sup/flash",
+          "gbb": "0",
+          "id": "1",
+          "lba": "0",
+          "lifetime": "1",
+          "majorAlarm": "no",
+          "mfgTm": "2026-01-25T14:20:35.456+00:00",
+          "minorAlarm": "no",
+          "modTs": "2026-02-10T14:19:55.789+00:00",
+          "model": "Micron_5300_MTFDDAK960TDS",
+          "monPolDn": "uni/fabric/monfab-default",
+          "operSt": "ok",
+          "peCycles": "65",
+          "readErr": "0",
+          "rev": "D3MU010",
+          "ser": "MSA23450789",
+          "status": "",
+          "tbw": "8.765432",
+          "type": "flash",
+          "vendor": "Micron",
+          "warning": "no",
+          "wlc": "0"
+        }
+      }
+    },
+    {
+      "eqptFlash": {
+        "attributes": {
+          "acc": "read-write",
+          "cap": "1831448",
+          "childAction": "",
+          "deltape": "0",
+          "descr": "flash",
+          "dn": "topology/pod-1/node-104/sys/ch/supslot-1/sup/flash",
+          "gbb": "0",
+          "id": "1",
+          "lba": "0",
+          "lifetime": "0",
+          "majorAlarm": "no",
+          "mfgTm": "2026-01-28T12:45:10.234+00:00",
+          "minorAlarm": "no",
+          "modTs": "2026-02-10T12:44:25.567+00:00",
+          "model": "Micron_5400_MTFDDAK1T9TGP",
+          "monPolDn": "uni/fabric/monfab-default",
+          "operSt": "ok",
+          "peCycles": "45",
+          "readErr": "0",
+          "rev": "D4CN010",
+          "ser": "MSA23451012",
+          "status": "",
+          "tbw": "5.432109",
+          "type": "flash",
+          "vendor": "Micron",
+          "warning": "no",
+          "wlc": "0"
+        }
+      }
+    }
+  ]
+}

--- a/tests/checks/switch_micron_ssd_firmware_check/test_switch_micron_ssd_firmware_check.py
+++ b/tests/checks/switch_micron_ssd_firmware_check/test_switch_micron_ssd_firmware_check.py
@@ -1,0 +1,110 @@
+import os
+import pytest
+import logging
+import importlib
+from helpers.utils import read_data
+
+script = importlib.import_module("aci-preupgrade-validation-script")
+
+test_function = "switch_micron_ssd_firmware_check"
+
+log = logging.getLogger(__name__)
+dir = os.path.dirname(os.path.abspath(__file__))
+
+# icurl queries
+eqptFlash = 'eqptFlash.json?query-target-filter=or(wcard(eqptFlash.model,"Micron_5300*"),wcard(eqptFlash.model,"Micron_5100*"),wcard(eqptFlash.model,"Micron_5400*"))'
+
+
+@pytest.mark.parametrize(
+    "icurl_outputs, tversion, expected_result, expected_data",
+    [
+        # PASS - No Micron SSDs found
+        (
+            {eqptFlash: []},
+            "6.0(1a)",
+            script.PASS,
+            [],
+        ),
+        # PASS - All Micron SSDs have current firmware
+        (
+            {eqptFlash: read_data(dir, "eqptFlash_pass.json")},
+            "6.0(1a)",
+            script.PASS,
+            [],
+        ),
+        # FAIL_O - M5100 with outdated firmware
+        (
+            {eqptFlash: read_data(dir, "eqptFlash_m5100_outdated.json")},
+            "6.0(1a)",
+            script.FAIL_O,
+            [
+                ["101", "Micron_5100_MTFDDAK256TBN", "D0MU070"],
+            ],
+        ),
+        # FAIL_O - M5300 D3CN with outdated firmware
+        (
+            {eqptFlash: read_data(dir, "eqptFlash_m5300_d3cn_outdated.json")},
+            "6.0(1a)",
+            script.FAIL_O,
+            [
+                ["102", "Micron_5300_MTFDDAK480TDS", "D3CN001"],
+            ],
+        ),
+        # FAIL_O - M5300 D3MU with outdated firmware
+        (
+            {eqptFlash: read_data(dir, "eqptFlash_m5300_d3mu_outdated.json")},
+            "6.0(1a)",
+            script.FAIL_O,
+            [
+                ["103", "Micron_5300_MTFDDAK960TDS", "D3MU003"],
+            ],
+        ),
+        # FAIL_O - M5400 with outdated firmware
+        (
+            {eqptFlash: read_data(dir, "eqptFlash_m5400_outdated.json")},
+            "6.0(1a)",
+            script.FAIL_O,
+            [
+                ["104", "Micron_5400_MTFDDAK1T9TGP", "D4CN003"],
+            ],
+        ),
+        # FAIL_O - Multiple SSDs with outdated firmware
+        (
+            {eqptFlash: read_data(dir, "eqptFlash_multiple_outdated.json")},
+            "6.0(1a)",
+            script.FAIL_O,
+            [
+                ["101", "Micron_5100_MTFDDAK256TBN", "D0MU070"],
+                ["102", "Micron_5300_MTFDDAK480TDS", "D3CN001"],
+                ["104", "Micron_5400_MTFDDAK1T9TGP", "D4CN003"],
+            ],
+        ),
+        # NA - Target version is 6.1(5e) or newer
+        (
+            {eqptFlash: read_data(dir, "eqptFlash_m5100_outdated.json")},
+            "6.1(5e)",
+            script.NA,
+            [],
+        ),
+        # NA - Target version is newer than 6.1(5e)
+        (
+            {eqptFlash: read_data(dir, "eqptFlash_m5100_outdated.json")},
+            "6.2(1a)",
+            script.NA,
+            [],
+        ),
+        # MANUAL - No target version provided
+        (
+            {eqptFlash: read_data(dir, "eqptFlash_m5100_outdated.json")},
+            None,
+            script.MANUAL,
+            [],
+        ),
+    ],
+)
+def test_logic(run_check, mock_icurl, tversion, expected_result, expected_data):
+    result = run_check(
+        tversion=script.AciVersion(tversion) if tversion else None,
+    )
+    assert result.result == expected_result
+    assert result.data == expected_data


### PR DESCRIPTION
Failure scenario test result on lab:

```
[Check 84/90] Switch SSD firmware version on Micron M5100/M5300/M5400 models...                                    FAIL - OUTAGE WARNING!!
  Node ID  SSD Model                  SSD Firmware Version
  -------  ---------                  --------------------
  101      Micron_5100_MTFDDAV240TCB  D0MU077
  102      Micron_5100_MTFDDAV240TCB  D0MU069
  2101     Micron_5300_MTFDDAV240TDS  D3CN001
  2102     Micron_5300_MTFDDAV240TDS  D3CN001
  2104     Micron_5400_MTFDDAV240TGA  D4MU002

  Recommended Action: 
        To avoid potential switch reloads due to a hap-reset after the APIC upgrade, contact Cisco TAC to upgrade the SSD firmware on the affected switches to at least the required versions:
         - Micron M5100: D0MU078
         - Micron M5300 (D3CN): D3CN003
         - Micron M5300 (D3MU): D3MU005
         - Micron M5400: D4CN005
        Alternatively, consider upgrading the ACI switches to at least version 16.1(5e) where this issue is resolved.
  Reference Document: https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#ssds-going-into-read-only-mode
```

Pass scenario test result on lab:

<<< No failed check result is displayed >>>

Fixes #323