### PR TITLE
Added pre-upgrade check for defect CSCwt69100

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -6532,34 +6532,6 @@ def wred_affected_model_check(tversion, fabric_nodes, **kwargs):
     return Result(result=NA, msg="No affected Fabric module found.")
 
 
-@check_wrapper(check_title="Stale dbgacEpgSummaryTask Objects")
-def stale_dbgacEpgSummaryTask_check(tversion, **kwargs):
-    result = PASS
-    headers = ["DN", "Start Time"]
-    data = []
-    recommended_action = "Contact Cisco TAC for next steps. For more details, refer to the workaround in [CSCwt69100](https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwt69100)."
-    doc_url = "https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#stale-dbgacepgsummarytask-objects"
-
-    if tversion and ((tversion.major1 == "6" and tversion.major2 == "1" and tversion.newer_than("6.1(5e)")) or tversion.newer_than("6.2(1g)")):
-        return Result(result=NA, msg=VER_NOT_AFFECTED, doc_url=doc_url)
-
-    threshold = datetime.utcnow() - timedelta(hours=24)
-    for obj in icurl("class", 'dbgacEpgSummaryTask.json?query-target-filter=eq(dbgacEpgSummaryTask.operSt,"processing")'):
-        attr = obj["dbgacEpgSummaryTask"]["attributes"]
-        dn = attr.get("dn", "")
-        start_ts = attr.get("startTs", "")
-        try:
-            task_dt = datetime.strptime(start_ts[:19], "%Y-%m-%dT%H:%M:%S")
-        except ValueError:
-            continue
-        if task_dt < threshold:
-            data.append([dn, start_ts])
-
-    if data:
-        result = FAIL_UF
-    return Result(result=result, headers=headers, data=data, recommended_action=recommended_action, doc_url=doc_url)
-
-
 @check_wrapper(check_title='N9K-C93180YC-FX3 Switch Memory Less Than 32GB')
 def n9k_c93180yc_fx3_switch_memory_check(fabric_nodes, **kwargs):
     result = PASS
@@ -6618,6 +6590,34 @@ def n9k_c93180yc_fx3_switch_memory_check(fabric_nodes, **kwargs):
             )
 
     return Result(result=result, msg=msg, headers=headers, data=data, recommended_action=recommended_action, doc_url=doc_url)
+
+
+@check_wrapper(check_title="Stale dbgacEpgSummaryTask Objects")
+def stale_dbgacEpgSummaryTask_check(tversion, **kwargs):
+    result = PASS
+    headers = ["DN", "Start Time"]
+    data = []
+    recommended_action = "Contact Cisco TAC for next steps. For more details, refer to the workaround in [CSCwt69100](https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwt69100)."
+    doc_url = "https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#stale-dbgacepgsummarytask-objects"
+
+    if tversion and ((tversion.major1 == "6" and tversion.major2 == "1" and tversion.newer_than("6.1(5e)")) or tversion.newer_than("6.2(1g)")):
+        return Result(result=NA, msg=VER_NOT_AFFECTED, doc_url=doc_url)
+
+    threshold = datetime.utcnow() - timedelta(hours=24)
+    for obj in icurl("class", 'dbgacEpgSummaryTask.json?query-target-filter=eq(dbgacEpgSummaryTask.operSt,"processing")'):
+        attr = obj["dbgacEpgSummaryTask"]["attributes"]
+        dn = attr.get("dn", "")
+        start_ts = attr.get("startTs", "")
+        try:
+            task_dt = datetime.strptime(start_ts[:19], "%Y-%m-%dT%H:%M:%S")
+        except ValueError:
+            continue
+        if task_dt < threshold:
+            data.append([dn, start_ts])
+
+    if data:
+        result = FAIL_UF
+    return Result(result=result, headers=headers, data=data, recommended_action=recommended_action, doc_url=doc_url)
 
 
 # ---- Script Execution ----
@@ -6793,8 +6793,9 @@ class CheckManager:
         inband_management_policy_misconfig_check,
         bgpProto_timer_policy_already_existing_check,
         wred_affected_model_check,
-        stale_dbgacEpgSummaryTask_check,
         n9k_c93180yc_fx3_switch_memory_check,
+        stale_dbgacEpgSummaryTask_check,
+
     ]
     ssh_checks = [
         # General

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -6532,6 +6532,34 @@ def wred_affected_model_check(tversion, fabric_nodes, **kwargs):
     return Result(result=NA, msg="No affected Fabric module found.")
 
 
+@check_wrapper(check_title="Stale dbgacEpgSummaryTask Objects")
+def stale_dbgacEpgSummaryTask_check(tversion, **kwargs):
+    result = PASS
+    headers = ["DN", "Start Time"]
+    data = []
+    recommended_action = "Contact Cisco TAC for next steps. For more details, refer to the workaround in [CSCwt69100](https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwt69100)."
+    doc_url = "https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#stale-dbgacepgsummarytask-objects"
+
+    if tversion and ((tversion.major1 == "6" and tversion.major2 == "1" and tversion.newer_than("6.1(5e)")) or tversion.newer_than("6.2(1g)")):
+        return Result(result=NA, msg=VER_NOT_AFFECTED, doc_url=doc_url)
+
+    threshold = datetime.utcnow() - timedelta(hours=24)
+    for obj in icurl("class", 'dbgacEpgSummaryTask.json?query-target-filter=eq(dbgacEpgSummaryTask.operSt,"processing")'):
+        attr = obj["dbgacEpgSummaryTask"]["attributes"]
+        dn = attr.get("dn", "")
+        start_ts = attr.get("startTs", "")
+        try:
+            task_dt = datetime.strptime(start_ts[:19], "%Y-%m-%dT%H:%M:%S")
+        except ValueError:
+            continue
+        if task_dt < threshold:
+            data.append([dn, start_ts])
+
+    if data:
+        result = FAIL_UF
+    return Result(result=result, headers=headers, data=data, recommended_action=recommended_action, doc_url=doc_url)
+
+
 # ---- Script Execution ----
 
 
@@ -6705,6 +6733,7 @@ class CheckManager:
         inband_management_policy_misconfig_check,
         bgpProto_timer_policy_already_existing_check,
         wred_affected_model_check,
+        stale_dbgacEpgSummaryTask_check,
     ]
     ssh_checks = [
         # General

--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -2833,7 +2833,7 @@ If any N9K-C93180YC-FX3 switch is flagged by this check, upgrade the switch memo
 
 ### Stale dbgacEpgSummaryTask Objects
 
-Due to [CSCwt69100][74], a stale `dbgacEpgSummaryTask` object stuck in `processing` state with empty content can cause the policymgr process to crash on all APICs during an upgrade or process restart.
+Due to [CSCwt69100][75], a stale `dbgacEpgSummaryTask` object stuck in `processing` state with empty content can cause the policymgr process to crash on all APICs during an upgrade or process restart.
 
 Affected versions: 6.1(5e) and below, or 6.2(1g).
 

--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -205,6 +205,7 @@ Items                                           | Defect       | This Script    
 [Inband Management Policy Misconfiguration][d33]| CSCwd40071   | :white_check_mark: | :no_entry_sign:
 [BgpProto timer policy already existing][d34]   | CSCwt78235   | :white_check_mark: | :no_entry_sign:
 [WRED with Affected FM Models][d35]             | CSCwt50713   | :white_check_mark: | :no_entry_sign:
+[Stale dbgacEpgSummaryTask Objects][d36]         | CSCwt69100   | :white_check_mark: | :no_entry_sign:
 
 [d1]: #ep-announce-compatibility
 [d2]: #eventmgr-db-size-defect-susceptibility
@@ -241,6 +242,7 @@ Items                                           | Defect       | This Script    
 [d33]: #inband-management-policy-misconfiguration
 [d34]: #bgpProto-timer-policy-already-existing
 [d35]: #wred-with-affected-fm-models
+[d36]: #stale-dbgacepgsummarytask-objects
 
 ## General Check Details
 
@@ -2819,6 +2821,15 @@ To avoid this issue, disable WRED on the affected nodes or upgrade to a release 
 This bug [CSCwt78235][71] validates `F0467` faults where `changeSet` contains 'bgpProt-policy-already-existing'. The fault indicates conflicting BGP protocol timer policy under an L3Outs deployed in same vrf under same node. If this fault is not resolved, l3out will not be programmed properly in the leaf after the clean reboot or the upgrade.
 
 
+### Stale dbgacEpgSummaryTask Objects
+
+Due to [CSCwt69100][74], a stale `dbgacEpgSummaryTask` object stuck in `processing` state with empty content can cause the policymgr process to crash on all APICs during an upgrade or process restart.
+
+Affected versions: 6.1(5e) and below, or 6.2(1g).
+
+Contact Cisco TAC for next steps. For more details, refer to the workaround in [CSCwt69100][74].
+
+
 [0]: https://github.com/datacenter/ACI-Pre-Upgrade-Validation-Script
 [1]: https://www.cisco.com/c/dam/en/us/td/docs/Website/datacenter/apicmatrix/index.html
 [2]: https://www.cisco.com/c/en/us/support/switches/nexus-9000-series-switches/products-release-notes-list.html
@@ -2893,3 +2904,4 @@ This bug [CSCwt78235][71] validates `F0467` faults where `changeSet` contains 'b
 [71]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwt78235
 [72]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwt50713
 [73]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwo74485
+[74]: https://bst.cloudapps.cisco.com/bugsearch/bug/CSCwt69100

--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -140,7 +140,6 @@ Items                                         | Faults         | This Script    
 [AVE End-of-life][c23]                                | :white_check_mark: | :no_entry_sign:
 [Shared Service with vzAny Consumer][c24]             | :white_check_mark: | :no_entry_sign:
 
-
 [c1]: #vpc-paired-leaf-switches
 [c2]: #overlapping-vlan-pool
 [c3]: #vnid-mismatch
@@ -208,7 +207,6 @@ Items                                           | Defect       | This Script    
 [N9K-C93180YC-FX3 Switch Memory Less Than 32GB][d36] | CSCwm42741   | :white_check_mark: | :no_entry_sign:
 [Stale dbgacEpgSummaryTask Objects][d37]         | CSCwt69100   | :white_check_mark: | :no_entry_sign:
 
-
 [d1]: #ep-announce-compatibility
 [d2]: #eventmgr-db-size-defect-susceptibility
 [d3]: #contract-port-22-defect
@@ -246,7 +244,6 @@ Items                                           | Defect       | This Script    
 [d35]: #wred-with-affected-fm-models
 [d36]: #n9k-c93180yc-fx3-switch-memory-less-than-32gb
 [d37]: #stale-dbgacepgsummarytask-objects
-
 
 ## General Check Details
 


### PR DESCRIPTION
**Summary:**
-This PR adds a new validation check: Stale dbgacEpgSummaryTask Objects.

-The check detects stale `dbgacEpgSummaryTask` objects stuck in `processing` state that can cause policymgr to crash on all APICs during upgrade (CSCwt69100).

**What Changed:**
- Added `stale_epg_summary_task_check` in `aci-preupgrade-validation-script.py`
- Added validation documentation in `docs/docs/validations.md`
- Added dedicated unit tests and test data under:
  `tests/checks/stale_epg_summary_task_check/`

**Check Behavior:**
- Returns `N/A` if target version is 6.1(6a) or above on the 6.1 release branch, or 6.2(2a) or above on the 6.2 release branch.
- Returns `PASS` if no `dbgacEpgSummaryTask` objects found in `processing` state
- Returns `PASS` if objects found but `startTs` is within 24 hours
- Returns `FAIL_UF` if target version is 6.1(5e) or below, or 6.2(1g).

**Test Results:**
- Pytest Logs: Full Run: 
[CSCwt69100_Pytest_FullRun_Logs.txt](https://github.com/user-attachments/files/29494228/CSCwt69100_Pytest_FullRun_Logs.txt)

- Pytest Logs: stale_epg_summary_task_check
[CSCwt69100_pytest.txt](https://github.com/user-attachments/files/29494270/CSCwt69100_pytest.txt)

- Script Full run:
[CSCwt69100_FullRun_logs.txt](https://github.com/user-attachments/files/29494517/CSCwt69100_FullRun_logs.txt)

- Script Run Logs (PASS / NA / FAIL):
[CSCwt69100_PASS:FAIL:NA_logs.txt](https://github.com/user-attachments/files/29494737/CSCwt69100_PASS.FAIL.NA_logs.txt)

Note: Added FAIL log from CU as lab repro is not feasible.