### PR TITLE
fix: stringify all values in `Result.data`

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -1333,13 +1333,26 @@ class Result:
     """Class to hold the result of a check."""
     __slots__ = ("result", "msg", "headers", "data", "unformatted_headers", "unformatted_data", "recommended_action", "doc_url")
 
+    @staticmethod
+    def _stringify_table_rows(rows):
+        """Convert every table cell value to string for stable sorting/printing."""
+        if rows is None:
+            return []
+        normalized = []
+        for row in rows:
+            if isinstance(row, (list, tuple)):
+                normalized.append([str(col) for col in row])
+            else:
+                normalized.append([str(row)])
+        return normalized
+
     def __init__(self, result=PASS, msg="", headers=None, data=None, unformatted_headers=None, unformatted_data=None, recommended_action="", doc_url=""):
         self.result = result
         self.msg = msg
         self.headers = headers if headers is not None else []
-        self.data = data if data is not None else []
+        self.data = self._stringify_table_rows(data)
         self.unformatted_headers = unformatted_headers if unformatted_headers is not None else []
-        self.unformatted_data = unformatted_data if unformatted_data is not None else []
+        self.unformatted_data = self._stringify_table_rows(unformatted_data)
         self.recommended_action = recommended_action
         self.doc_url = doc_url
 

--- a/tests/checks/n9k_c9408_model_lem_count_check/test_n9k_c9408_model_lem_count_check.py
+++ b/tests/checks/n9k_c9408_model_lem_count_check/test_n9k_c9408_model_lem_count_check.py
@@ -71,7 +71,7 @@ eqptLC_api = 'eqptLC.json?query-target-filter=eq(eqptLC.model,"N9K-X9400-16W")'
             "6.2(1g)",
             read_data(dir, "fabricNode_n9k_c9408.json"),
             script.FAIL_O,
-            [["101", "N9K-C9408", "N9K-X9400-16W", 6]],
+            [["101", "N9K-C9408", "N9K-X9400-16W", "6"]],
             "",
         ),
         # Applicable mid-train version 6.1(5e), less than 6 LEMs on C9408 -> PASS
@@ -89,7 +89,7 @@ eqptLC_api = 'eqptLC.json?query-target-filter=eq(eqptLC.model,"N9K-X9400-16W")'
             "6.1(5e)",
             read_data(dir, "fabricNode_n9k_c9408.json"),
             script.FAIL_O,
-            [["101", "N9K-C9408", "N9K-X9400-16W", 6]],
+            [["101", "N9K-C9408", "N9K-X9400-16W", "6"]],
             "",
         ),
         # Version not affected (fixed in 6.1(6)+)
@@ -107,7 +107,7 @@ eqptLC_api = 'eqptLC.json?query-target-filter=eq(eqptLC.model,"N9K-X9400-16W")'
             "6.1(2f)",
             read_data(dir, "fabricNode_n9k_c9408.json"),
             script.FAIL_O,
-            [["101", "N9K-C9408", "N9K-X9400-16W", 6]],
+            [["101", "N9K-C9408", "N9K-X9400-16W", "6"]],
             "",
         ),
         # Count only C9408 nodes and only matching LEM model
@@ -117,8 +117,8 @@ eqptLC_api = 'eqptLC.json?query-target-filter=eq(eqptLC.model,"N9K-X9400-16W")'
             read_data(dir, "fabricNode_mixed.json"),
             script.FAIL_O,
             [
-                ["101", "N9K-C9408", "N9K-X9400-16W", 6],
-                ["102", "N9K-C9408", "N9K-X9400-16W", 6],
+                ["101", "N9K-C9408", "N9K-X9400-16W", "6"],
+                ["102", "N9K-C9408", "N9K-X9400-16W", "6"],
             ],
             "",
         ),

--- a/tests/checks/r_leaf_compatibility_check/test_r_leaf_compatibility_check.py
+++ b/tests/checks/r_leaf_compatibility_check/test_r_leaf_compatibility_check.py
@@ -53,7 +53,7 @@ infraSetPol = "uni/infra/settings.json"
             "4.1(2a)",
             "4.2(2a)",
             script.FAIL_O,
-            [["4.2(2a)", "Present", True]],
+            [["4.2(2a)", "Present", "True"]],
         ),
         # PASS - bug version upgrade, no RL
         (
@@ -80,7 +80,7 @@ infraSetPol = "uni/infra/settings.json"
             "4.2(3a)",
             "5.2(3a)",
             script.FAIL_O,
-            [["5.2(3a)", "Present", False]],
+            [["5.2(3a)", "Present", "False"]],
         ),
         # PASS - Fix ver to 5.x, no RL
         (

--- a/tests/checks/rogue_ep_coop_exception_mac_check/test_rogue_ep_coop_exception_mac_check.py
+++ b/tests/checks/rogue_ep_coop_exception_mac_check/test_rogue_ep_coop_exception_mac_check.py
@@ -66,14 +66,14 @@ presListener_api += '?query-target-filter=and(eq(presListener.lstDn,"exceptcont"
             "6.0(3e)",
             "5.2(3e)",
             script.FAIL_O,
-            [[5, "N/A"]],
+            [["5", "N/A"]],
         ),
         (
             {exception_mac_api: read_data(dir, "rogue_mac_response.json")},
             "6.1(3g)",
             "5.2(3e)",
             script.FAIL_O,
-            [[5, "N/A"]],
+            [["5", "N/A"]],
         ),
         # Affected (post-APIC upgrade, pre-switch upgrade) cases
         # tversion == cversion (affected target), no exception MACs
@@ -121,7 +121,7 @@ presListener_api += '?query-target-filter=and(eq(presListener.lstDn,"exceptcont"
             "6.0(3e)",
             "6.0(3e)",
             script.FAIL_O,
-            [[5, "only 31 found out of 32"]],
+            [["5", "only 31 found out of 32"]],
         ),
         (
             {
@@ -131,7 +131,7 @@ presListener_api += '?query-target-filter=and(eq(presListener.lstDn,"exceptcont"
             "6.1(3g)",
             "6.1(3g)",
             script.FAIL_O,
-            [[5, "only 31 found out of 32"]],
+            [["5", "only 31 found out of 32"]],
         ),
         (
             {
@@ -141,7 +141,7 @@ presListener_api += '?query-target-filter=and(eq(presListener.lstDn,"exceptcont"
             "6.0(3e)",
             "6.0(3e)",
             script.FAIL_O,
-            [[5, "only 27 found out of 32"]],
+            [["5", "only 27 found out of 32"]],
         ),
         (
             {
@@ -151,7 +151,7 @@ presListener_api += '?query-target-filter=and(eq(presListener.lstDn,"exceptcont"
             "6.1(3g)",
             "6.1(3g)",
             script.FAIL_O,
-            [[5, "only 27 found out of 32"]],
+            [["5", "only 27 found out of 32"]],
         ),
         (
             {
@@ -161,7 +161,7 @@ presListener_api += '?query-target-filter=and(eq(presListener.lstDn,"exceptcont"
             "6.0(3e)",
             "6.0(3e)",
             script.FAIL_O,
-            [[5, "only 1 found out of 32"]],
+            [["5", "only 1 found out of 32"]],
         ),
         (
             {
@@ -171,7 +171,7 @@ presListener_api += '?query-target-filter=and(eq(presListener.lstDn,"exceptcont"
             "6.1(3g)",
             "6.1(3g)",
             script.FAIL_O,
-            [[5, "only 1 found out of 32"]],
+            [["5", "only 1 found out of 32"]],
         ),
         (
             {
@@ -181,7 +181,7 @@ presListener_api += '?query-target-filter=and(eq(presListener.lstDn,"exceptcont"
             "6.0(3e)",
             "6.0(3e)",
             script.FAIL_O,
-            [[5, "only 0 found out of 32"]],
+            [["5", "only 0 found out of 32"]],
         ),
         (
             {
@@ -191,7 +191,7 @@ presListener_api += '?query-target-filter=and(eq(presListener.lstDn,"exceptcont"
             "6.1(3g)",
             "6.1(3g)",
             script.FAIL_O,
-            [[5, "only 0 found out of 32"]],
+            [["5", "only 0 found out of 32"]],
         ),
     ],
 )

--- a/tests/test_Result.py
+++ b/tests/test_Result.py
@@ -1,0 +1,28 @@
+import importlib
+
+script = importlib.import_module("aci-preupgrade-validation-script")
+
+
+def test_print_result_handles_mixed_type_rows_without_error():
+    # Verify that Result stringifies all cell values, so data.sort() in print_result never fails.
+    r = script.Result(
+        result=script.FAIL_O,
+        headers=["col1"],
+        data=[[1], ["2"]],
+        unformatted_headers=["col1"],
+        unformatted_data=[[3], ["4"]],
+    )
+    # All values must already be strings after construction.
+    assert r.data == [["1"], ["2"]]
+    assert r.unformatted_data == [["3"], ["4"]]
+    # print_result must not raise.
+    script.print_result(
+        index=1,
+        total=1,
+        title="Mixed type table",
+        result=script.FAIL_O,
+        headers=r.headers,
+        data=r.data,
+        unformatted_headers=r.unformatted_headers,
+        unformatted_data=r.unformatted_data,
+    )


### PR DESCRIPTION
There are some checks that forget to stringify the values they add in `Result.data`.

This doesn't cause any issue if the value type is consistent across the rows for the same column. However, this causes an issue when the value type is inconsistent even for the same column.

Here is an example where the "%" column for the first two rows have integers while the last one has a string. In theory, this should be fixed in each check. But there is always a risk of overlooking something. So, in this commit, we are stringify all `data` values when they are added to the `Result` class instance at its construction time. 

```
    "data": [
      {
        "Pod": "1",
        "Node": "201",
        "Code": "F1821",
        "%": 100,     <---
        "Description": "Disk usage for /mnt/ifc/log is high on node 201 of fabric ifav87-fabric with a hostname ifav87-spine1"
      },
      {
        "Pod": "1",
        "Node": "110",
        "Code": "F1821",
        "%": 94,     <---
        "Description": "Disk usage for /mnt/ifc/cfg is high on node 110 of fabric ifav87-fabric with a hostname ifav87-leaf10"
      },
      {
        "Pod": "1",
        "Node": "110",
        "Code": "F1821",
        "%": "NA",     <---
        "Description": "Disk usage for /mnt/ifc/log is high on node 110 of fabric ifav87-fabric with a hostname ifav87-leaf10"
      }
    ],
```

When such an inconsistency happens, the script fails at the very end when it prints the results of all checks with the following error.

```
Abort due to unexpected error - '<' not supported between instances of 'str' and 'int'
```