### PR TITLE
Update inband management policy misconfiguration check to include IPv6 address...

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -6372,7 +6372,7 @@ def inband_management_policy_misconfig_check(cversion, tversion, **kwargs):
     doc_url = "https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#inband-management-policy-misconfiguration"
     
     if (cversion.older_than("5.2(8d)")) and (tversion.newer_than("6.0(4c)") or tversion.same_as("6.0(4c)")):
-        mgmtRsInBStNodes = icurl('class', 'mgmtRsInBStNode.json?query-target-filter=or(eq(mgmtRsInBStNode.addr,"0.0.0.0"),eq(mgmtRsInBStNode.gw,"0.0.0.0"))')
+        mgmtRsInBStNodes = icurl('class', 'mgmtRsInBStNode.json?query-target-filter=and(or(eq(mgmtRsInBStNode.addr,"0.0.0.0"),eq(mgmtRsInBStNode.gw,"0.0.0.0")),or(eq(mgmtRsInBStNode.v6Addr,"::"),eq(mgmtRsInBStNode.v6Gw,"::")))')
         for mgmtRsInBStNode in mgmtRsInBStNodes:
             attrs = mgmtRsInBStNode["mgmtRsInBStNode"]["attributes"]
             addr = attrs['addr']

--- a/tests/checks/inband_management_policy_misconfig_check/mgmtRsInBStNode_invalid_addr_and_gw_config.json
+++ b/tests/checks/inband_management_policy_misconfig_check/mgmtRsInBStNode_invalid_addr_and_gw_config.json
@@ -7,6 +7,8 @@
                 "configurationMode": "static",
                 "dn": "uni/tn-mgmt/mgmtp-default/inb-inb/rsinBStNode-[topology/pod-1/node-103]",
                 "gw": "0.0.0.0",
+                "v6Addr": "::",
+                "v6Gw": "::",
                 "modTs": "2024-12-20T07:45:21.454+00:00",
                 "rType": "mo",
                 "rn": "rsinBStNode-[topology/pod-1/node-103]",

--- a/tests/checks/inband_management_policy_misconfig_check/mgmtRsInBStNode_invalid_address_config.json
+++ b/tests/checks/inband_management_policy_misconfig_check/mgmtRsInBStNode_invalid_address_config.json
@@ -7,6 +7,8 @@
                 "configurationMode": "static",
                 "dn": "uni/tn-mgmt/mgmtp-default/inb-inb/rsinBStNode-[topology/pod-1/node-103]",
                 "gw": "191.1.1.1",
+                "v6Addr": "::",
+                "v6Gw": "::",
                 "modTs": "2024-12-20T07:45:21.454+00:00",
                 "rType": "mo",
                 "rn": "rsinBStNode-[topology/pod-1/node-103]",

--- a/tests/checks/inband_management_policy_misconfig_check/mgmtRsInBStNode_invalid_gateway_config.json
+++ b/tests/checks/inband_management_policy_misconfig_check/mgmtRsInBStNode_invalid_gateway_config.json
@@ -7,6 +7,8 @@
                 "configurationMode": "static",
                 "dn": "uni/tn-mgmt/mgmtp-default/inb-inb/rsinBStNode-[topology/pod-1/node-103]",
                 "gw": "0.0.0.0",
+                "v6Addr": "::",
+                "v6Gw": "::",
                 "modTs": "2024-12-20T07:45:21.454+00:00",
                 "rType": "mo",
                 "rn": "rsinBStNode-[topology/pod-1/node-103]",

--- a/tests/checks/inband_management_policy_misconfig_check/test_inband_management_policy_misconfig_check.py
+++ b/tests/checks/inband_management_policy_misconfig_check/test_inband_management_policy_misconfig_check.py
@@ -8,7 +8,7 @@ script = importlib.import_module("aci-preupgrade-validation-script")
 log = logging.getLogger(__name__)
 dir = os.path.dirname(os.path.abspath(__file__))
 test_function = "inband_management_policy_misconfig_check"
-mgmtRsInBStNode = 'mgmtRsInBStNode.json?query-target-filter=or(eq(mgmtRsInBStNode.addr,"0.0.0.0"),eq(mgmtRsInBStNode.gw,"0.0.0.0"))'
+mgmtRsInBStNode = 'mgmtRsInBStNode.json?query-target-filter=and(or(eq(mgmtRsInBStNode.addr,"0.0.0.0"),eq(mgmtRsInBStNode.gw,"0.0.0.0")),or(eq(mgmtRsInBStNode.v6Addr,"::"),eq(mgmtRsInBStNode.v6Gw,"::")))'
 
 @pytest.mark.parametrize(
     "icurl_outputs, cversion, tversion, expected_result, expected_data",


### PR DESCRIPTION
Update inband management policy misconfiguration check to include IPv6 address and gateway validation. Adjusted query filter in the validation script and updated test cases to reflect changes in address configurations.