### PR TITLE
Added check for certificate expiration issue

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -6891,8 +6891,7 @@ def certificate_expiration_check(cversion, username, password, fabric_nodes, **k
             recommended_action = (
                     "Manually verify certificate expiry for all affected nodes. "
                     "\n\tFor APIC factory certificates, run `acidiag verifyapic` on each affected APIC. "
-                    "\n\tFor leaf/spine certificates, validate 'moquery -c pkiFabricNodeSSLCertificate' and check 'validityNotAfter' values via APIC API "
-                    "and resolve any connectivity or data parsing issues before upgrade."
+                    "\n\tFor leaf/spine certificates, validate 'moquery -c pkiFabricNodeSSLCertificate' and check 'validityNotAfter' values for affected nodes."
                 )
         elif has_critical and has_major:
             result = FAIL_O

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -6702,6 +6702,116 @@ def stale_dbgacEpgSummaryTask_check(tversion, **kwargs):
     return Result(result=result, headers=headers, data=data, recommended_action=recommended_action, doc_url=doc_url)
 
 
+@check_wrapper(check_title='Certificate Expiration Check')
+def certificate_expiration_check(cversion, username, password, fabric_nodes, **kwargs):
+    result = PASS
+    headers = ["Fault Code", "Severity", "Description"]
+    data = []
+    recommended_action = ""
+    doc_url = 'https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#certificate-expiration-check'
+
+    fault_min_versions = {
+        "F4501": "6.0(4c)", "F4502": "6.0(4c)",  # KeyRing cert expiring/expired
+        "F4503": "6.1(1e)", "F4617": "6.1(1e)",  # TP cert expired/expiring
+        "F3081": "3.1(2f)", "F3082": "3.1(2f)",  # SAML encryption cert expiring/expired
+        "F4752": "6.1(5e)", "F4753": "6.1(5e)",  # Factory certificate expired/expiring
+    }
+    FACTORY_CERT_MIN_VERSION = "6.1(5e)"
+    FACTORY_CERT_EXPIRING_DAYS = 30
+
+    has_critical = has_major = has_error = False
+
+    applicable_codes = [code for code, ver in fault_min_versions.items() if not cversion.older_than(ver)]
+    if applicable_codes:
+        fault_filter = ",".join('eq(faultInst.code,"{}")'.format(code) for code in applicable_codes)
+        for faultInst in icurl('class', 'faultInst.json?query-target-filter=or({})'.format(fault_filter)):
+            fault_attrs = faultInst['faultInst']['attributes']
+            if fault_attrs['lc'] not in ("raised", "soaking"):
+                continue
+            data.append([fault_attrs['code'], fault_attrs['severity'], fault_attrs['descr']])
+            if fault_attrs['severity'] == 'critical':
+                has_critical = True
+            elif fault_attrs['severity'] == 'major':
+                has_major = True
+
+    if cversion.older_than(FACTORY_CERT_MIN_VERSION) and username and password:
+        date_format = "%b %d %H:%M:%S %Y"
+        current_date_re = re.compile(
+            r'[A-Z][a-z]{2}\s+(?P<mon>[A-Z][a-z]{2})\s+(?P<day>\d+)\s+(?P<time>\d{2}:\d{2}:\d{2})\s+\w+\s+(?P<year>\d{4})'
+        )
+        cert_expiry_re = re.compile(
+            r'notAfter=(?P<date>[A-Z][a-z]{2}\s+\d+\s+\d{2}:\d{2}:\d{2}\s+\d{4})'
+        )
+
+        controllers = (node for node in fabric_nodes if node["fabricNode"]["attributes"]["role"] == "controller")
+        controllers = list(controllers)
+        for controller in controllers:
+            node_attrs = controller["fabricNode"]["attributes"]
+            node_id = node_attrs["id"]
+            node_name = node_attrs["name"]
+            node_addr = node_attrs.get("address")
+            if not node_addr:
+                continue
+            try:
+                c = Connection(node_addr)
+                c.username = username
+                c.password = password
+                c.log = LOG_FILE
+                c.connect()
+                c.cmd("date")
+                current_date_match = current_date_re.search(c.output)
+                c.cmd("acidiag verifyapic")
+                cert_expiry_match = cert_expiry_re.search(c.output)
+            except Exception as e:
+                data.append(["N/A", "error",
+                             "APIC {} ({}): unable to verify factory certificate - {}".format(node_id, node_name, e)])
+                has_error = True
+                continue
+
+            try:
+                current_date = datetime.strptime(
+                    "{mon} {day} {time} {year}".format(**current_date_match.groupdict()), date_format
+                )
+            except (AttributeError, ValueError):
+                data.append(["N/A", "error",
+                             "APIC {} ({}): unable to determine current date".format(node_id, node_name)])
+                has_error = True
+                continue
+
+            try:
+                cert_expiry = datetime.strptime(" ".join(cert_expiry_match.group("date").split()), date_format)
+            except (AttributeError, ValueError):
+                data.append(["N/A", "error",
+                             "APIC {} ({}): unable to determine factory certificate expiry date".format(node_id, node_name)])
+                has_error = True
+                continue
+
+            if cert_expiry <= current_date:
+                data.append(["N/A", "critical",
+                             "APIC {} ({}): factory certificate expired on {} UTC".format(node_id, node_name, cert_expiry)])
+                has_critical = True
+            elif (cert_expiry - current_date).days <= FACTORY_CERT_EXPIRING_DAYS:
+                data.append(["N/A", "major",
+                             "APIC {} ({}): factory certificate expiring on {} UTC".format(node_id, node_name, cert_expiry)])
+                has_major = True
+
+    if data:
+        if has_error:
+            result = ERROR
+            recommended_action = 'Manually verify the factory certificate expiry using `acidiag verifyapic` on the affected APIC(s).'
+        elif has_critical and has_major:
+            result = FAIL_O
+            recommended_action = 'Renew expired certificate(s) immediately. For certificate(s) approaching expiry, renew before they expire to avoid service disruption.'
+        elif has_critical:
+            result = FAIL_O
+            recommended_action = 'Renew the certificate(s) immediately to restore functionality.'
+        elif has_major:
+            result = MANUAL
+            recommended_action = 'Renew the certificate(s) before they expire to avoid service disruption.'
+
+    return Result(result=result, headers=headers, data=data, recommended_action=recommended_action, doc_url=doc_url)
+
+
 # ---- Script Execution ----
 
 
@@ -6816,6 +6926,7 @@ class CheckManager:
         equipment_disk_limits_exceeded,
         apic_vmm_inventory_sync_faults_check,
         apic_storage_inode_check,
+        certificate_expiration_check,
 
         # Configurations
         vpc_paired_switches_check,

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -6721,7 +6721,6 @@ def certificate_expiration_check(cversion, username, password, fabric_nodes, **k
 
     has_critical = has_major = has_error = False
 
-    # Check for certificate-related faults based on the current version and the minimum versions for each fault code.
     applicable_codes = [code for code, ver in fault_min_versions if not cversion.older_than(ver)]
     if applicable_codes:
         fault_filter = ",".join('eq(faultInst.code,"{}")'.format(code) for code in applicable_codes)
@@ -6735,7 +6734,6 @@ def certificate_expiration_check(cversion, username, password, fabric_nodes, **k
             elif fault_attrs['severity'] == 'major':
                 has_major = True
 
-    # Check factory certificate expiration on APICs if the version is older than FACTORY_CERT_MIN_VERSION and credentials are provided.
     if cversion.older_than(FACTORY_CERT_MIN_VERSION) and username and password:
         date_format = "%b %d %H:%M:%S %Y"
         current_date_re = re.compile(
@@ -6800,98 +6798,12 @@ def certificate_expiration_check(cversion, username, password, fabric_nodes, **k
                              "APIC {} ({}): factory certificate expiring on {} UTC".format(controller_id, controller_name, cert_expiry)])
                 has_major = True
 
-    # Leaf/spine certificate check via API validityNotAfter.
-    if fabric_nodes:
-        tz = None
-        try:
-            from datetime import timezone as tz
-        except ImportError:
-            pass
-        
-        if tz is not None:
-            now_utc = datetime.now(tz.utc)
-        else:
-            now_utc = datetime.utcnow()
-
-        switch_nodes_by_id = {
-            str(node_attrs.get("id", "")): node_attrs
-            for fabric_node in fabric_nodes
-            for node_attrs in [fabric_node.get("fabricNode", {}).get("attributes", {})]
-            if node_attrs.get("role") in ("leaf", "spine") and node_attrs.get("id")
-        }
-
-        if switch_nodes_by_id:
-            certificate_mos = icurl("class", "pkiFabricNodeSSLCertificate.json") or []
-
-            for certificate_mo in certificate_mos:
-                cert_attrs = certificate_mo.get("pkiFabricNodeSSLCertificate", {}).get("attributes", {})
-                cert_node_id = str(cert_attrs.get("nodeId", ""))
-
-                if cert_node_id not in switch_nodes_by_id:
-                    continue
-
-                node_attrs = switch_nodes_by_id[cert_node_id]
-                node_name = node_attrs.get("name", "N/A")
-
-                validity_not_after = cert_attrs.get("validityNotAfter", "")
-                if not validity_not_after:
-                    data.append([
-                        "N/A",
-                        "error",
-                        "Node {} ({}): unable to determine certificate expiry date".format(cert_node_id, node_name)
-                    ])
-                    has_error = True
-                    continue
-
-                expiry_text = validity_not_after.split("+", 1)[0].split("Z", 1)[0]
-                expiry_utc = None
-                for timestamp_format in ("%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S"):
-                    try:
-                        parsed_dt = datetime.strptime(expiry_text, timestamp_format)
-                        if tz is not None:
-                            expiry_utc = parsed_dt.replace(tzinfo=tz.utc)
-                        else:
-                            expiry_utc = parsed_dt
-                        break
-                    except ValueError:
-                        pass
-
-                if expiry_utc is None:
-                    data.append([
-                        "N/A",
-                        "error",
-                        "Node {} ({}): unable to parse certificate expiry date '{}'".format(
-                            cert_node_id, node_name, validity_not_after
-                        )
-                    ])
-                    has_error = True
-                    continue
-
-                if expiry_utc <= now_utc:
-                    data.append([
-                        "N/A",
-                        "critical",
-                        "Node {} ({}): certificate expired on {} UTC".format(
-                            cert_node_id, node_name, expiry_utc.replace(tzinfo=None)
-                        ),
-                    ])
-                    has_critical = True
-                elif (expiry_utc - now_utc).days <= CERT_EXPIRING_DAYS:
-                    data.append([
-                        "N/A",
-                        "major",
-                        "Node {} ({}): certificate expiring on {} UTC".format(
-                            cert_node_id, node_name, expiry_utc.replace(tzinfo=None)
-                        ),
-                    ])
-                    has_major = True
     if data:
         if has_error:
             result = ERROR
             recommended_action = (
                     "Manually verify certificate expiry for all affected nodes. "
-                    "\n\tFor APIC factory certificates, run `acidiag verifyapic` on each affected APIC. "
-                    "\n\tFor leaf/spine certificates, run 'moquery -c pkiFabricNodeSSLCertificate' on any APIC and check 'validityNotAfter' value for affected nodes."
+                    "\n\tFor APIC factory certificates, run `acidiag verifyapic` on each affected APIC."
                 )
         elif has_critical and has_major:
             result = FAIL_O

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -6888,7 +6888,12 @@ def certificate_expiration_check(cversion, username, password, fabric_nodes, **k
     if data:
         if has_error:
             result = ERROR
-            recommended_action = 'Manually verify the factory certificate expiry using `acidiag verifyapic` on the affected APIC(s).'
+            recommended_action = (
+                    "Manually verify certificate expiry for all affected nodes. "
+                    "\n\tFor APIC factory certificates, run `acidiag verifyapic` on each affected APIC. "
+                    "\n\tFor leaf/spine certificates, validate 'moquery -c pkiFabricNodeSSLCertificate' and check 'validityNotAfter' values via APIC API "
+                    "and resolve any connectivity or data parsing issues before upgrade."
+                )
         elif has_critical and has_major:
             result = FAIL_O
             recommended_action = 'Renew expired certificate(s) immediately. For certificate(s) approaching expiry, renew before they expire to avoid service disruption.'

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -6891,7 +6891,7 @@ def certificate_expiration_check(cversion, username, password, fabric_nodes, **k
             recommended_action = (
                     "Manually verify certificate expiry for all affected nodes. "
                     "\n\tFor APIC factory certificates, run `acidiag verifyapic` on each affected APIC. "
-                    "\n\tFor leaf/spine certificates, validate 'moquery -c pkiFabricNodeSSLCertificate' and check 'validityNotAfter' values for affected nodes."
+                    "\n\tFor leaf/spine certificates, run 'moquery -c pkiFabricNodeSSLCertificate' on any APIC and check 'validityNotAfter' value for affected nodes."
                 )
         elif has_critical and has_major:
             result = FAIL_O

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -6710,18 +6710,18 @@ def certificate_expiration_check(cversion, username, password, fabric_nodes, **k
     recommended_action = ""
     doc_url = 'https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#certificate-expiration-check'
 
-    fault_min_versions = {
-        "F4501": "6.0(4c)", "F4502": "6.0(4c)",  # KeyRing cert expiring/expired
-        "F4503": "6.1(1e)", "F4617": "6.1(1e)",  # TP cert expired/expiring
-        "F3081": "3.1(2f)", "F3082": "3.1(2f)",  # SAML encryption cert expiring/expired
-        "F4752": "6.1(5e)", "F4753": "6.1(5e)",  # Factory certificate expired/expiring
-    }
+    fault_min_versions = [
+        ("F4501", "6.0(4c)"), ("F4502", "6.0(4c)"),  # KeyRing cert expiring/expired
+        ("F4503", "6.1(1e)"), ("F4617", "6.1(1e)"),  # TP cert expired/expiring
+        ("F3081", "3.1(2f)"), ("F3082", "3.1(2f)"),  # SAML encryption cert expiring/expired
+        ("F4752", "6.1(5e)"), ("F4753", "6.1(5e)"),  # Factory certificate expired/expiring
+    ]
     FACTORY_CERT_MIN_VERSION = "6.1(5e)"
     FACTORY_CERT_EXPIRING_DAYS = 30
 
     has_critical = has_major = has_error = False
 
-    applicable_codes = [code for code, ver in fault_min_versions.items() if not cversion.older_than(ver)]
+    applicable_codes = [code for code, ver in fault_min_versions if not cversion.older_than(ver)]
     if applicable_codes:
         fault_filter = ",".join('eq(faultInst.code,"{}")'.format(code) for code in applicable_codes)
         for faultInst in icurl('class', 'faultInst.json?query-target-filter=or({})'.format(fault_filter)):

--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -6717,10 +6717,11 @@ def certificate_expiration_check(cversion, username, password, fabric_nodes, **k
         ("F4752", "6.1(5e)"), ("F4753", "6.1(5e)"),  # Factory certificate expired/expiring
     ]
     FACTORY_CERT_MIN_VERSION = "6.1(5e)"
-    FACTORY_CERT_EXPIRING_DAYS = 30
+    CERT_EXPIRING_DAYS = 30
 
     has_critical = has_major = has_error = False
 
+    # Check for certificate-related faults based on the current version and the minimum versions for each fault code.
     applicable_codes = [code for code, ver in fault_min_versions if not cversion.older_than(ver)]
     if applicable_codes:
         fault_filter = ",".join('eq(faultInst.code,"{}")'.format(code) for code in applicable_codes)
@@ -6734,6 +6735,7 @@ def certificate_expiration_check(cversion, username, password, fabric_nodes, **k
             elif fault_attrs['severity'] == 'major':
                 has_major = True
 
+    # Check factory certificate expiration on APICs if the version is older than FACTORY_CERT_MIN_VERSION and credentials are provided.
     if cversion.older_than(FACTORY_CERT_MIN_VERSION) and username and password:
         date_format = "%b %d %H:%M:%S %Y"
         current_date_re = re.compile(
@@ -6743,28 +6745,31 @@ def certificate_expiration_check(cversion, username, password, fabric_nodes, **k
             r'notAfter=(?P<date>[A-Z][a-z]{2}\s+\d+\s+\d{2}:\d{2}:\d{2}\s+\d{4})'
         )
 
-        controllers = (node for node in fabric_nodes if node["fabricNode"]["attributes"]["role"] == "controller")
-        controllers = list(controllers)
-        for controller in controllers:
-            node_attrs = controller["fabricNode"]["attributes"]
-            node_id = node_attrs["id"]
-            node_name = node_attrs["name"]
-            node_addr = node_attrs.get("address")
-            if not node_addr:
+        for controller in (node for node in fabric_nodes if node.get("fabricNode", {}).get("attributes", {}).get("role") == "controller"):
+            controller_attrs = controller.get("fabricNode", {}).get("attributes", {})
+            controller_id = controller_attrs.get("id", "N/A")
+            controller_name = controller_attrs.get("name", "N/A")
+            controller_address = controller_attrs.get("address")
+
+            if not controller_address:
+                data.append(["N/A", "error",
+                             "APIC {} ({}): unable to determine controller address".format(controller_id, controller_name)])
+                has_error = True
                 continue
+                
             try:
-                c = Connection(node_addr)
+                c = Connection(controller_address)
                 c.username = username
                 c.password = password
                 c.log = LOG_FILE
                 c.connect()
-                c.cmd("date")
+
+                c.cmd("date; acidiag verifyapic")
                 current_date_match = current_date_re.search(c.output)
-                c.cmd("acidiag verifyapic")
                 cert_expiry_match = cert_expiry_re.search(c.output)
             except Exception as e:
                 data.append(["N/A", "error",
-                             "APIC {} ({}): unable to verify factory certificate - {}".format(node_id, node_name, e)])
+                             "APIC {} ({}): unable to verify factory certificate - {}".format(controller_id, controller_name, e)])
                 has_error = True
                 continue
 
@@ -6774,7 +6779,7 @@ def certificate_expiration_check(cversion, username, password, fabric_nodes, **k
                 )
             except (AttributeError, ValueError):
                 data.append(["N/A", "error",
-                             "APIC {} ({}): unable to determine current date".format(node_id, node_name)])
+                             "APIC {} ({}): unable to determine current date".format(controller_id, controller_name)])
                 has_error = True
                 continue
 
@@ -6782,19 +6787,104 @@ def certificate_expiration_check(cversion, username, password, fabric_nodes, **k
                 cert_expiry = datetime.strptime(" ".join(cert_expiry_match.group("date").split()), date_format)
             except (AttributeError, ValueError):
                 data.append(["N/A", "error",
-                             "APIC {} ({}): unable to determine factory certificate expiry date".format(node_id, node_name)])
+                             "APIC {} ({}): unable to determine factory certificate expiry date".format(controller_id, controller_name)])
                 has_error = True
                 continue
 
             if cert_expiry <= current_date:
                 data.append(["N/A", "critical",
-                             "APIC {} ({}): factory certificate expired on {} UTC".format(node_id, node_name, cert_expiry)])
+                             "APIC {} ({}): factory certificate expired on {} UTC".format(controller_id, controller_name, cert_expiry)])
                 has_critical = True
-            elif (cert_expiry - current_date).days <= FACTORY_CERT_EXPIRING_DAYS:
+            elif (cert_expiry - current_date).days <= CERT_EXPIRING_DAYS:
                 data.append(["N/A", "major",
-                             "APIC {} ({}): factory certificate expiring on {} UTC".format(node_id, node_name, cert_expiry)])
+                             "APIC {} ({}): factory certificate expiring on {} UTC".format(controller_id, controller_name, cert_expiry)])
                 has_major = True
 
+    # Leaf/spine certificate check via API validityNotAfter.
+    if fabric_nodes:
+        tz = None
+        try:
+            from datetime import timezone as tz
+        except ImportError:
+            pass
+        
+        if tz is not None:
+            now_utc = datetime.now(tz.utc)
+        else:
+            now_utc = datetime.utcnow()
+
+        switch_nodes_by_id = {
+            str(node_attrs.get("id", "")): node_attrs
+            for fabric_node in fabric_nodes
+            for node_attrs in [fabric_node.get("fabricNode", {}).get("attributes", {})]
+            if node_attrs.get("role") in ("leaf", "spine") and node_attrs.get("id")
+        }
+
+        if switch_nodes_by_id:
+            certificate_mos = icurl("class", "pkiFabricNodeSSLCertificate.json") or []
+
+            for certificate_mo in certificate_mos:
+                cert_attrs = certificate_mo.get("pkiFabricNodeSSLCertificate", {}).get("attributes", {})
+                cert_node_id = str(cert_attrs.get("nodeId", ""))
+
+                if cert_node_id not in switch_nodes_by_id:
+                    continue
+
+                node_attrs = switch_nodes_by_id[cert_node_id]
+                node_name = node_attrs.get("name", "N/A")
+
+                validity_not_after = cert_attrs.get("validityNotAfter", "")
+                if not validity_not_after:
+                    data.append([
+                        "N/A",
+                        "error",
+                        "Node {} ({}): unable to determine certificate expiry date".format(cert_node_id, node_name)
+                    ])
+                    has_error = True
+                    continue
+
+                expiry_text = validity_not_after.split("+", 1)[0].split("Z", 1)[0]
+                expiry_utc = None
+                for timestamp_format in ("%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S"):
+                    try:
+                        parsed_dt = datetime.strptime(expiry_text, timestamp_format)
+                        if tz is not None:
+                            expiry_utc = parsed_dt.replace(tzinfo=tz.utc)
+                        else:
+                            expiry_utc = parsed_dt
+                        break
+                    except ValueError:
+                        pass
+
+                if expiry_utc is None:
+                    data.append([
+                        "N/A",
+                        "error",
+                        "Node {} ({}): unable to parse certificate expiry date '{}'".format(
+                            cert_node_id, node_name, validity_not_after
+                        )
+                    ])
+                    has_error = True
+                    continue
+
+                if expiry_utc <= now_utc:
+                    data.append([
+                        "N/A",
+                        "critical",
+                        "Node {} ({}): certificate expired on {} UTC".format(
+                            cert_node_id, node_name, expiry_utc.replace(tzinfo=None)
+                        ),
+                    ])
+                    has_critical = True
+                elif (expiry_utc - now_utc).days <= CERT_EXPIRING_DAYS:
+                    data.append([
+                        "N/A",
+                        "major",
+                        "Node {} ({}): certificate expiring on {} UTC".format(
+                            cert_node_id, node_name, expiry_utc.replace(tzinfo=None)
+                        ),
+                    ])
+                    has_major = True
     if data:
         if has_error:
             result = ERROR

--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -87,6 +87,7 @@ Items                                         | Faults         | This Script    
 [Equipment Disk Limits][f20]                  | F1820: 80% -minor<br>F1821: -major<br>F1822: -critical | :white_check_mark: | :no_entry_sign:
 [VMM Inventory Partially Synced][f21]         | F0132: comp-ctrlr-operational-issues | :white_check_mark: | :no_entry_sign:
 [APIC Storage Inode Usage][f22]               | F4388: 75% - 85% -warning<br>F4389: 85% - 90% -major<br>F4390: 90% or more -critical | :white_check_mark: | :no_entry_sign:
+[Certificate Expiration Check][f23]           | F4501/F4502: KeyRing expiring/expired<br>F4617/F4503: TP expiring/expired<br>F3081/F3082: SAML expiring/expired<br>F4752/F4753: Factory expiring/expired | :white_check_mark: | :no_entry_sign:
 
 [f1]: #apic-disk-space-usage
 [f2]: #standby-apic-disk-space-usage
@@ -110,6 +111,7 @@ Items                                         | Faults         | This Script    
 [f20]: #equipment-disk-limits
 [f21]: #vmm-inventory-partially-synced
 [f22]: #apic-storage-inode-usage
+[f23]: #certificate-expiration-check
 
 ### Configuration Checks
 
@@ -1639,7 +1641,115 @@ To recover from this fault, try the following action
     type            : operational
     ```
     
-    
+### Certificate Expiration Check
+
+ACI uses various X.509 certificates for security and authentication purposes. If these certificates expire or are about to expire, it can cause service disruptions or failures. The fabric will raise different faults depending on the certificate type.
+
+**Expiring Certificates (Major Severity):**
+
+* **F4501**: KeyRing X.509 Certificate expiring - This fault occurs when a custom KeyRing X.509 Certificate is going to expire in one month.
+
+* **F3081**: SAML X.509 Certificate expiring - This fault occurs when the SAML X.509 Certificate is going to expire in one month.
+
+* **F4617**: TP X.509 Certificate expiring - This fault occurs when a Trust Point X.509 Certificate is expiring.
+
+* **F4752**: Factory X.509 Certificate expiring - This fault occurs when the factory Certificate is expiring.
+
+
+**Expired Certificates (Critical Severity):**
+
+* **F4502**: KeyRing X.509 Certificate expired - This fault occurs when a custom KeyRing X.509 Certificate has expired.
+
+* **F4503**: TP X.509 Certificate expired - This fault occurs when a Trust Point X.509 Certificate has expired.
+
+* **F3082**: SAML X.509 Certificate expired - This fault occurs when the SAML Encryption X.509 Certificate has expired.
+
+* **F4753**: Factory X.509 Certificate expired - This fault occurs when the factory Certificate has expired.
+
+
+**Recommended Actions:**
+
+* For expiring certificates (F4501, F3081, F4617, F4572): Renew the certificate(s) before they expire to avoid service disruption.
+
+* For expired certificates (F4502, F4503, F3082, F4573): Renew the certificate(s) immediately to restore functionality.
+
+!!! example "Fault Example (F4502: Expired KeyRing Certificate)"
+    The following shows an example of an expired KeyRing certificate:
+    ```
+    admin@apic1:~> moquery -c faultInst -f 'fault.Inst.code=="F4502"'
+    Total Objects shown: 1
+     
+    # fault.Inst
+    code             : F4502
+    ack              : no
+    alert            : no
+    annotation       :
+    cause            : cert-expired
+    changeSet        :
+    childAction      :
+    created          : 2026-05-12T05:23:26.549+00:00
+    delegated        : no
+    descr            : KeyRing Certificate THD_KEYRING expired
+    dn               : uni/userext/pkiext/keyring-THD_KEYRING/fault-F4502
+    domain           : security
+    extMngdBy        : undefined
+    highestSeverity  : critical
+    lastTransition   : 2026-05-12T05:25:51.231+00:00
+    lc               : raised
+    modTs            : never
+    occur            : 1
+    origSeverity     : critical
+    prevSeverity     : critical
+    rn               : fault-F4502
+    rule             : pki-key-ring-custom-key-ring-expired
+    severity         : critical
+    status           :
+    subject          : security-provider
+    title            :
+    type             : operational
+    uid              :
+    userdom          : all
+    ```
+
+!!! example "Fault Example (F4501: Expiring KeyRing Certificate)"
+    The following shows an example of a KeyRing certificate expiring in one month:
+    ```
+    admin@apic1:~> moquery -c faultInst -f 'fault.Inst.code=="F4501"'
+    Total Objects shown: 1
+     
+    # fault.Inst
+    code             : F4501
+    ack              : no
+    alert            : no
+    annotation       :
+    cause            : cert-expiring
+    changeSet        :
+    childAction      :
+    created          : 2026-04-12T05:23:26.549+00:00
+    delegated        : no
+    descr            : KeyRing Certificate THD_KEYRING expiring in one month
+    dn               : uni/userext/pkiext/keyring-THD_KEYRING/fault-F4501
+    domain           : security
+    extMngdBy        : undefined
+    highestSeverity  : major
+    lastTransition   : 2026-04-12T05:25:51.231+00:00
+    lc               : raised
+    modTs            : never
+    occur            : 1
+    origSeverity     : major
+    prevSeverity     : major
+    rn               : fault-F4501
+    rule             : pki-key-ring-custom-key-ring-expiring
+    severity         : major
+    status           :
+    subject          : security-provider
+    title            :
+    type             : operational
+    uid              :
+    userdom          : all
+    ```
+
+
 ## Configuration Check Details
 
 ### VPC-paired Leaf switches                       

--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -1645,6 +1645,8 @@ To recover from this fault, try the following action
 
 ACI uses various X.509 certificates for security and authentication purposes. If these certificates expire or are about to expire, it can cause service disruptions or failures. The fabric will raise different faults depending on the certificate type.
 
+The script also validates X.509 certificates on all leaf and spine switch nodes by querying the pkiFabricNodeSSLCertificate API. These certificates are used for fabric node authentication and secure communication between switches and APICs.
+
 **Expiring Certificates (Major Severity):**
 
 * **F4501**: KeyRing X.509 Certificate expiring - This fault occurs when a custom KeyRing X.509 Certificate is going to expire in one month.

--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -1669,9 +1669,9 @@ ACI uses various X.509 certificates for security and authentication purposes. If
 
 **Recommended Actions:**
 
-* For expiring certificates (F4501, F3081, F4617, F4572): Renew the certificate(s) before they expire to avoid service disruption.
+* For expiring certificates (F4501, F3081, F4617, F4752): Renew the certificate(s) before they expire to avoid service disruption.
 
-* For expired certificates (F4502, F4503, F3082, F4573): Renew the certificate(s) immediately to restore functionality.
+* For expired certificates (F4502, F4503, F3082, F4753): Renew the certificate(s) immediately to restore functionality.
 
 !!! example "Fault Example (F4502: Expired KeyRing Certificate)"
     The following shows an example of an expired KeyRing certificate:

--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -1645,8 +1645,6 @@ To recover from this fault, try the following action
 
 ACI uses various X.509 certificates for security and authentication purposes. If these certificates expire or are about to expire, it can cause service disruptions or failures. The fabric will raise different faults depending on the certificate type.
 
-The script also validates X.509 certificates on all leaf and spine switch nodes by querying the pkiFabricNodeSSLCertificate API. These certificates are used for fabric node authentication and secure communication between switches and APICs.
-
 **Expiring Certificates (Major Severity):**
 
 * **F4501**: KeyRing X.509 Certificate expiring - This fault occurs when a custom KeyRing X.509 Certificate is going to expire in one month.

--- a/tests/checks/certificate_expiration_check/faultInst_F3081.json
+++ b/tests/checks/certificate_expiration_check/faultInst_F3081.json
@@ -1,0 +1,13 @@
+[
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F3081",
+                "severity": "major",
+                "lc": "raised",
+                "descr": "SAML Signing Certificate expiring in one month",
+                "dn": "uni/userext/samlext/samlidp-IDP1/fault-F3081"
+            }
+        }
+    }
+]

--- a/tests/checks/certificate_expiration_check/faultInst_F3082.json
+++ b/tests/checks/certificate_expiration_check/faultInst_F3082.json
@@ -1,0 +1,13 @@
+[
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F3082",
+                "severity": "critical",
+                "lc": "raised",
+                "descr": "SAML Encryption Certificate has expired",
+                "dn": "uni/userext/samlext/samlencert-default/fault-F3082"
+            }
+        }
+    }
+]

--- a/tests/checks/certificate_expiration_check/faultInst_F4501.json
+++ b/tests/checks/certificate_expiration_check/faultInst_F4501.json
@@ -1,0 +1,13 @@
+[
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F4501",
+                "severity": "major",
+                "lc": "raised",
+                "descr": "KeyRing Certificate THD_KEYRING expiring",
+                "dn": "uni/userext/pkiext/keyring-THD_KEYRING/fault-F4501"
+            }
+        }
+    }
+]

--- a/tests/checks/certificate_expiration_check/faultInst_F4502.json
+++ b/tests/checks/certificate_expiration_check/faultInst_F4502.json
@@ -1,0 +1,13 @@
+[
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F4502",
+                "severity": "critical",
+                "lc": "raised",
+                "descr": "KeyRing Certificate THD_KEYRING expired",
+                "dn": "uni/userext/pkiext/keyring-THD_KEYRING/fault-F4502"
+            }
+        }
+    }
+]

--- a/tests/checks/certificate_expiration_check/faultInst_F4503.json
+++ b/tests/checks/certificate_expiration_check/faultInst_F4503.json
@@ -1,0 +1,13 @@
+[
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F4503",
+                "severity": "critical",
+                "lc": "raised",
+                "descr": "TP Certificate THD_CA expired",
+                "dn": "uni/userext/pkiext/tp-THD_CA/fault-F4503"
+            }
+        }
+    }
+]

--- a/tests/checks/certificate_expiration_check/faultInst_F4617.json
+++ b/tests/checks/certificate_expiration_check/faultInst_F4617.json
@@ -1,0 +1,13 @@
+[
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F4617",
+                "severity": "major",
+                "lc": "raised",
+                "descr": "TP Certificate expiring",
+                "dn": "uni/fabric/comm-default/https/fault-F4617"
+            }
+        }
+    }
+]

--- a/tests/checks/certificate_expiration_check/faultInst_F4752.json
+++ b/tests/checks/certificate_expiration_check/faultInst_F4752.json
@@ -1,0 +1,13 @@
+[
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F4752",
+                "severity": "major",
+                "lc": "raised",
+                "descr": "Factory certificate expiring",
+                "dn": "topology/pod-1/node-1/sys/ch/fault-F4752"
+            }
+        }
+    }
+]

--- a/tests/checks/certificate_expiration_check/faultInst_F4753.json
+++ b/tests/checks/certificate_expiration_check/faultInst_F4753.json
@@ -1,0 +1,13 @@
+[
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F4753",
+                "severity": "critical",
+                "lc": "raised",
+                "descr": "Factory certificate expired",
+                "dn": "topology/pod-1/node-1/sys/ch/fault-F4753"
+            }
+        }
+    }
+]

--- a/tests/checks/certificate_expiration_check/faultInst_cleared.json
+++ b/tests/checks/certificate_expiration_check/faultInst_cleared.json
@@ -1,0 +1,13 @@
+[
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F4502",
+                "severity": "critical",
+                "lc": "retaining",
+                "descr": "KeyRing Certificate THD_KEYRING expired",
+                "dn": "uni/userext/pkiext/keyring-THD_KEYRING/fault-F4502"
+            }
+        }
+    }
+]

--- a/tests/checks/certificate_expiration_check/faultInst_mixed.json
+++ b/tests/checks/certificate_expiration_check/faultInst_mixed.json
@@ -1,0 +1,46 @@
+[
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F4501",
+                "severity": "major",
+                "lc": "raised",
+                "descr": "KeyRing Certificate KEYRING1 expiring",
+                "dn": "uni/userext/pkiext/keyring-KEYRING1/fault-F4501"
+            }
+        }
+    },
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F4502",
+                "severity": "critical",
+                "lc": "raised",
+                "descr": "KeyRing Certificate THD_KEYRING expired",
+                "dn": "uni/userext/pkiext/keyring-THD_KEYRING/fault-F4502"
+            }
+        }
+    },
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F3081",
+                "severity": "major",
+                "lc": "raised",
+                "descr": "SAML Signing Certificate expiring in one month",
+                "dn": "uni/userext/samlext/samlidp-IDP1/fault-F3081"
+            }
+        }
+    },
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F3082",
+                "severity": "critical",
+                "lc": "raised",
+                "descr": "SAML Encryption Certificate has expired",
+                "dn": "uni/userext/samlext/samlencert-default/fault-F3082"
+            }
+        }
+    }
+]

--- a/tests/checks/certificate_expiration_check/faultInst_multiple_expired.json
+++ b/tests/checks/certificate_expiration_check/faultInst_multiple_expired.json
@@ -1,0 +1,35 @@
+[
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F4502",
+                "severity": "critical",
+                "lc": "raised",
+                "descr": "KeyRing Certificate THD_KEYRING expired",
+                "dn": "uni/userext/pkiext/keyring-THD_KEYRING/fault-F4502"
+            }
+        }
+    },
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F4503",
+                "severity": "critical",
+                "lc": "raised",
+                "descr": "TP Certificate THD_CA expired",
+                "dn": "uni/userext/pkiext/tp-THD_CA/fault-F4503"
+            }
+        }
+    },
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F3082",
+                "severity": "critical",
+                "lc": "raised",
+                "descr": "SAML Encryption Certificate has expired",
+                "dn": "uni/userext/samlext/samlencert-default/fault-F3082"
+            }
+        }
+    }
+]

--- a/tests/checks/certificate_expiration_check/faultInst_multiple_expiring.json
+++ b/tests/checks/certificate_expiration_check/faultInst_multiple_expiring.json
@@ -1,0 +1,35 @@
+[
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F4501",
+                "severity": "major",
+                "lc": "raised",
+                "descr": "KeyRing Certificate THD_KEYRING expiring",
+                "dn": "uni/userext/pkiext/keyring-THD_KEYRING/fault-F4501"
+            }
+        }
+    },
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F3081",
+                "severity": "major",
+                "lc": "raised",
+                "descr": "SAML Signing Certificate expiring in one month",
+                "dn": "uni/userext/samlext/samlidp-IDP1/fault-F3081"
+            }
+        }
+    },
+    {
+        "faultInst": {
+            "attributes": {
+                "code": "F4617",
+                "severity": "major",
+                "lc": "raised",
+                "descr": "TP Certificate expiring",
+                "dn": "uni/fabric/comm-default/https/fault-F4617"
+            }
+        }
+    }
+]

--- a/tests/checks/certificate_expiration_check/test_certificate_expiration_check.py
+++ b/tests/checks/certificate_expiration_check/test_certificate_expiration_check.py
@@ -3,9 +3,33 @@ import pytest
 import logging
 import importlib
 from helpers.utils import read_data
+from datetime import datetime
+
+FIXED_UTC_NOW = datetime(2026, 7, 15, 6, 35, 30)
+DATE_OUTPUT = "Wed Jul 15 06:35:30 UTC 2026\nfab-apic#"
+
+LEAF_SPINE_EXPIRED_TS = "2024-05-14T20:25:42.000+00:00"
+LEAF_SPINE_EXPIRING_TS = "2026-08-01T06:57:40.000+00:00"
+
 
 script = importlib.import_module("aci-preupgrade-validation-script")
 Result = script.Result
+
+@pytest.fixture(autouse=True)
+def hardcode_current_time(monkeypatch):
+    class FrozenDateTime(datetime):
+        @classmethod
+        def utcnow(cls):
+            return FIXED_UTC_NOW
+        
+        @classmethod
+        def now(cls, tz=None):
+            if tz is not None:
+                return FIXED_UTC_NOW.replace(tzinfo=tz)
+            else:
+                return FIXED_UTC_NOW
+    
+    monkeypatch.setattr(script, "datetime", FrozenDateTime)
 
 log = logging.getLogger(__name__)
 dir = os.path.dirname(os.path.abspath(__file__))
@@ -30,6 +54,7 @@ faultInst = fault_query(MASTER_ORDER)
 faultInst_pre_factory = fault_query(["F4501", "F4502", "F4503", "F4617", "F3081", "F3082"])
 faultInst_keyring_saml = fault_query(["F4501", "F4502", "F3081", "F3082"])
 faultInst_saml = fault_query(["F3081", "F3082"])
+pkiFabricNodeSSLCertificate = "pkiFabricNodeSSLCertificate.json"
 
 
 # --- Factory certificate (F4752/F4753) SSH check test data ---
@@ -41,6 +66,16 @@ fabric_nodes_multi = [
     {"fabricNode": {"attributes": {"id": "1", "name": "apic1", "role": "controller", "address": "10.0.0.1"}}},
     {"fabricNode": {"attributes": {"id": "2", "name": "apic2", "role": "controller", "address": "10.0.0.2"}}},
     {"fabricNode": {"attributes": {"id": "3", "name": "apic3", "role": "controller", "address": "10.0.0.3"}}},
+]
+
+fabric_nodes_leaf_spine = [
+    {"fabricNode": {"attributes": {"id": "101", "name": "leaf101", "role": "leaf", "dn": "topology/pod-1/node-101"}}},
+    {"fabricNode": {"attributes": {"id": "201", "name": "spine201", "role": "spine", "dn": "topology/pod-1/node-201"}}},
+]
+
+fabric_nodes_controller_leaf = [
+    {"fabricNode": {"attributes": {"id": "1", "name": "apic1", "role": "controller", "address": "10.0.0.1"}}},
+    {"fabricNode": {"attributes": {"id": "101", "name": "leaf101", "role": "leaf", "dn": "topology/pod-1/node-101"}}},
 ]
 
 DATE_OUTPUT = "Wed Jul 15 06:35:30 UTC 2026\nfab-apic#"
@@ -78,8 +113,11 @@ def ssh_cmds(outputs):
         outputs = {"10.0.0.1": outputs}
     return {
         addr: [
-            {"cmd": "date", "output": DATE_OUTPUT, "exception": None},
-            {"cmd": "acidiag verifyapic", "output": out, "exception": None},
+            {
+                "cmd": "date; acidiag verifyapic",
+                "output": "{}\n{}".format(DATE_OUTPUT, out),
+                "exception": None
+            },
         ]
         for addr, out in outputs.items()
     }
@@ -398,6 +436,53 @@ def ssh_cmds(outputs):
                  "APIC 1 (apic1): unable to verify factory certificate - Simulated exception at connect()"],
             ],
         ),
+        # ERROR - APIC output has no parseable current date
+        (
+            {
+                faultInst_pre_factory: []
+            },
+            False,
+            {
+                "10.0.0.1": [
+                    {
+                        "cmd": "date; acidiag verifyapic",
+                        "output": "BADDATE\nnotAfter=May 14 20:25:42 2024 GMT\n",
+                        "exception": None
+                    },
+                ]
+            },
+            "6.1(4a)",
+            fabric_nodes_ssh,
+            script.ERROR,
+            [
+                ["N/A", "error",
+                "APIC 1 (apic1): unable to determine current date"],
+            ],
+        ),
+
+        # ERROR - APIC output missing parseable notAfter
+        (
+            {
+                faultInst_pre_factory: []
+            },
+            False,
+            {
+                "10.0.0.1": [
+                    {
+                        "cmd": "date; acidiag verifyapic",
+                        "output": "Wed Jul 15 06:35:30 UTC 2026\nopenssl_check: Manufacturing certificate details\n",
+                        "exception": None
+                    },
+                ]
+            },
+            "6.1(4a)",
+            fabric_nodes_ssh,
+            script.ERROR,
+            [
+                ["N/A", "error",
+                "APIC 1 (apic1): unable to determine factory certificate expiry date"],
+            ],
+        ),
         # FAIL_O - combined: a raised fault AND an expired manufacturing cert (both reported)
         (
             {faultInst_pre_factory: read_data(dir, "faultInst_F4502.json")},
@@ -427,6 +512,204 @@ def ssh_cmds(outputs):
             [
                 ["N/A", "critical",
                  "APIC 2 (apic2): factory certificate expired on 2024-05-14 20:25:42 UTC"],
+            ],
+        ),
+        # MANUAL - leaf/spine cert expiring within threshold
+        (
+            {
+                faultInst: [],
+                pkiFabricNodeSSLCertificate: [
+                    {
+                        "pkiFabricNodeSSLCertificate": {
+                            "attributes": {
+                                "nodeId": "101",
+                                "validityNotAfter": LEAF_SPINE_EXPIRING_TS
+                            }
+                        }
+                    }
+                ],
+            },
+            False,
+            {},
+            "6.1(5e)",
+            fabric_nodes_leaf_spine,
+            script.MANUAL,
+            [
+                ["N/A", "major",
+                 "Node 101 (leaf101): certificate expiring on 2026-08-01 06:57:40 UTC"],
+            ],
+        ),
+        # FAIL_O - leaf/spine cert expired via pkiFabricNodeSSLCertificate validityNotAfter
+        (
+            {
+                faultInst: [],
+                pkiFabricNodeSSLCertificate: [
+                    {
+                        "pkiFabricNodeSSLCertificate": {
+                            "attributes": {
+                                "nodeId": "101",
+                                "validityNotAfter": "2024-05-14T20:25:42.000+00:00"
+                            }
+                        }
+                    }
+                ],
+            },
+            False,
+            {},
+            "6.1(5e)",
+            fabric_nodes_leaf_spine,
+            script.FAIL_O,
+            [
+                ["N/A", "critical",
+                 "Node 101 (leaf101): certificate expired on 2024-05-14 20:25:42 UTC"],
+            ],
+        ),
+        # FAIL_O - leaf/spine combination: one expired and one expiring
+        (
+            {
+                faultInst: [],
+                pkiFabricNodeSSLCertificate: [
+                    {
+                        "pkiFabricNodeSSLCertificate": {
+                            "attributes": {
+                                "nodeId": "101",
+                                "validityNotAfter": LEAF_SPINE_EXPIRED_TS
+                            }
+                        }
+                    },
+                    {
+                        "pkiFabricNodeSSLCertificate": {
+                            "attributes": {
+                                "nodeId": "201",
+                                "validityNotAfter": LEAF_SPINE_EXPIRING_TS
+                            }
+                        }
+                    },
+                ],
+            },
+            False,
+            {},
+            "6.1(5e)",
+            fabric_nodes_leaf_spine,
+            script.FAIL_O,
+            [
+                ["N/A", "critical",
+                 "Node 101 (leaf101): certificate expired on 2024-05-14 20:25:42 UTC"],
+                ["N/A", "major",
+                 "Node 201 (spine201): certificate expiring on 2026-08-01 06:57:40 UTC"],
+            ],
+        ),
+        # ERROR - leaf/spine cert missing validityNotAfter
+        (
+            {
+                faultInst: [],
+                pkiFabricNodeSSLCertificate: [
+                    {
+                        "pkiFabricNodeSSLCertificate": {
+                            "attributes": {
+                                "nodeId": "201",
+                                "validityNotAfter": ""
+                            }
+                        }
+                    }
+                ],
+            },
+            False,
+            {},
+            "6.1(5e)",
+            fabric_nodes_leaf_spine,
+            script.ERROR,
+            [
+                ["N/A", "error",
+                 "Node 201 (spine201): unable to determine certificate expiry date"],
+            ],
+        ),
+        # ERROR - leaf/spine cert has unparseable validityNotAfter
+        (
+            {
+                faultInst: [],
+                pkiFabricNodeSSLCertificate: [
+                    {
+                        "pkiFabricNodeSSLCertificate": {
+                            "attributes": {
+                                "nodeId": "101",
+                                "validityNotAfter": "not-a-date"
+                            }
+                        }
+                    }
+                ],
+            },
+            False,
+            {},
+            "6.1(5e)",
+            fabric_nodes_leaf_spine,
+            script.ERROR,
+            [
+                ["N/A", "error",
+                 "Node 101 (leaf101): unable to parse certificate expiry date 'not-a-date'"],
+            ],
+        ),
+        # FAIL_O - APIC fault + APIC factory cert expired + leaf cert expired
+        (
+            {
+                faultInst_pre_factory: read_data(dir, "faultInst_F4502.json"),
+                pkiFabricNodeSSLCertificate: [
+                    {
+                        "pkiFabricNodeSSLCertificate": {
+                            "attributes": {
+                                "nodeId": "101",
+                                "validityNotAfter": LEAF_SPINE_EXPIRED_TS
+                            }
+                        }
+                    }
+                ],
+            },
+            False,
+            ssh_cmds(VERIFYAPIC_EXPIRED),
+            "6.1(4a)",
+            fabric_nodes_controller_leaf,
+            script.FAIL_O,
+            [
+                ["F4502", "critical", "KeyRing Certificate THD_KEYRING expired"],
+                ["N/A", "critical",
+                 "APIC 1 (apic1): factory certificate expired on 2024-05-14 20:25:42 UTC"],
+                ["N/A", "critical",
+                 "Node 101 (leaf101): certificate expired on 2024-05-14 20:25:42 UTC"],
+            ],
+        ),
+        # ERROR - mixed leaf/spine data: one expired + one missing validityNotAfter (error takes priority)
+        (
+            {
+                faultInst: [],
+                pkiFabricNodeSSLCertificate: [
+                    {
+                        "pkiFabricNodeSSLCertificate": {
+                            "attributes": {
+                                "nodeId": "101",
+                                "validityNotAfter": LEAF_SPINE_EXPIRED_TS
+                            }
+                        }
+                    },
+                    {
+                        "pkiFabricNodeSSLCertificate": {
+                            "attributes": {
+                                "nodeId": "201",
+                                "validityNotAfter": ""
+                            }
+                        }
+                    },
+                ],
+            },
+            False,
+            {},
+            "6.1(5e)",
+            fabric_nodes_leaf_spine,
+            script.ERROR,
+            [
+                ["N/A", "critical",
+                "Node 101 (leaf101): certificate expired on 2024-05-14 20:25:42 UTC"],
+                ["N/A", "error",
+                "Node 201 (spine201): unable to determine certificate expiry date"],
             ],
         ),
     ],

--- a/tests/checks/certificate_expiration_check/test_certificate_expiration_check.py
+++ b/tests/checks/certificate_expiration_check/test_certificate_expiration_check.py
@@ -1,0 +1,442 @@
+import os
+import pytest
+import logging
+import importlib
+from helpers.utils import read_data
+
+script = importlib.import_module("aci-preupgrade-validation-script")
+Result = script.Result
+
+log = logging.getLogger(__name__)
+dir = os.path.dirname(os.path.abspath(__file__))
+
+test_function = "certificate_expiration_check"
+
+
+# Fault codes in the same order as `fault_min_versions` (dict insertion order),
+# which is the order the check builds the OR filter.
+MASTER_ORDER = ["F4501", "F4502", "F4503", "F4617", "F3081", "F3082", "F4752", "F4753"]
+
+
+def fault_query(codes):
+    ordered = [c for c in MASTER_ORDER if c in codes]
+    return 'faultInst.json?query-target-filter=or({})'.format(
+        ",".join('eq(faultInst.code,"{}")'.format(c) for c in ordered)
+    )
+
+
+# icurl queries per applicable version range
+faultInst = fault_query(MASTER_ORDER)                                    # cversion >= 6.1(5e)
+faultInst_pre_factory = fault_query(["F4501", "F4502", "F4503", "F4617", "F3081", "F3082"])  # 6.1(1e)–6.1(5e)
+faultInst_keyring_saml = fault_query(["F4501", "F4502", "F3081", "F3082"])                    # 6.0(4c)–6.1(1e)
+faultInst_saml = fault_query(["F3081", "F3082"])                                              # 3.1(2f)–6.0(4c)
+
+
+# --- Factory certificate (F4752/F4753) SSH check test data ---
+fabric_nodes_ssh = [
+    {"fabricNode": {"attributes": {"id": "1", "name": "apic1", "role": "controller", "address": "10.0.0.1"}}},
+]
+
+fabric_nodes_multi = [
+    {"fabricNode": {"attributes": {"id": "1", "name": "apic1", "role": "controller", "address": "10.0.0.1"}}},
+    {"fabricNode": {"attributes": {"id": "2", "name": "apic2", "role": "controller", "address": "10.0.0.2"}}},
+    {"fabricNode": {"attributes": {"id": "3", "name": "apic3", "role": "controller", "address": "10.0.0.3"}}},
+]
+
+DATE_OUTPUT = "Wed Jul 15 06:35:30 UTC 2026\nfab-apic#"
+
+VERIFYAPIC_EXPIRED = """\
+openssl_check: Manufacturing certificate details
+issuer=CN=Cisco Manufacturing CA,O=Cisco Systems
+notBefore=Jul  6 19:33:57 2019 GMT
+notAfter=May 14 20:25:42 2024 GMT
+openssl_check: passed
+all_checks: passed
+"""
+
+VERIFYAPIC_EXPIRING = """\
+openssl_check: Manufacturing certificate details
+issuer=CN=Cisco Manufacturing CA,O=Cisco Systems
+notBefore=Jul  6 19:33:57 2019 GMT
+notAfter=Aug  1 06:57:40 2026 GMT
+openssl_check: passed
+all_checks: passed
+"""
+
+VERIFYAPIC_VALID = """\
+openssl_check: Manufacturing certificate details
+issuer=CN=Cisco Manufacturing CA,O=Cisco Systems
+notBefore=Jul  6 19:33:57 2019 GMT
+notAfter=May 14 20:25:42 2029 GMT
+openssl_check: passed
+all_checks: passed
+"""
+
+
+def ssh_cmds(outputs):
+    if isinstance(outputs, str):
+        outputs = {"10.0.0.1": outputs}
+    return {
+        addr: [
+            {"cmd": "date", "output": DATE_OUTPUT, "exception": None},
+            {"cmd": "acidiag verifyapic", "output": out, "exception": None},
+        ]
+        for addr, out in outputs.items()
+    }
+
+@pytest.mark.parametrize(
+    "icurl_outputs, conn_failure, conn_cmds, cversion, fabric_nodes, expected_result, expected_data",
+    [
+        
+        # ==== cversion >= 6.1(5e): all 8 fault codes, SSH skipped ====
+
+        # PASS - no certificate faults
+        (
+            {
+                faultInst: []
+            },
+            False, 
+            {}, 
+            "6.1(5e)", 
+            [],
+            script.PASS,
+            [],
+        ),
+        # MANUAL - only expiring certificate (F4501 - KeyRing)
+        (
+            {
+                faultInst: read_data(dir, "faultInst_F4501.json")
+            },
+            False, 
+            {}, 
+            "6.1(5e)",
+            [],
+            script.MANUAL,
+            [
+                ["F4501", "major", "KeyRing Certificate THD_KEYRING expiring"],
+            ],
+        ),
+        # MANUAL - only expiring certificate (F3081 - SAML)
+        (
+            {
+                faultInst: read_data(dir, "faultInst_F3081.json")
+            },
+            False, 
+            {}, 
+            "6.1(5e)", 
+            [],
+            script.MANUAL,
+            [
+                ["F3081", "major", "SAML Signing Certificate expiring in one month"],
+            ],
+        ),
+        # MANUAL - only expiring certificate (F4617 - TP)
+        (
+            {
+                faultInst: read_data(dir, "faultInst_F4617.json")
+            },
+            False, 
+            {}, 
+            "6.1(5e)", 
+            [],
+            script.MANUAL,
+            [
+                ["F4617", "major", "TP Certificate expiring"],
+            ],
+        ),
+        # MANUAL - only expiring factory certificate (F4752 - Factory)
+        (
+            {
+                faultInst: read_data(dir, "faultInst_F4752.json")
+            },
+            False,
+            {},
+            "6.1(5e)",
+            [],
+            script.MANUAL,
+            [
+                ["F4752", "major", "Factory certificate expiring"],
+            ],
+        ),
+        # MANUAL - multiple expiring certificates
+        (
+            {
+                faultInst: read_data(dir, "faultInst_multiple_expiring.json")
+            },
+            False, 
+            {}, 
+            "6.1(5e)", 
+            [],
+            script.MANUAL,
+            [
+                ["F4501", "major", "KeyRing Certificate THD_KEYRING expiring"],
+                ["F3081", "major", "SAML Signing Certificate expiring in one month"],
+                ["F4617", "major", "TP Certificate expiring"],
+            ],
+        ),
+        # FAIL_O - only expired certificate (F4502 - KeyRing)
+        (
+            {
+                faultInst: read_data(dir, "faultInst_F4502.json")
+            },
+            False, 
+            {}, 
+            "6.1(5e)", 
+            [],
+            script.FAIL_O,
+            [
+                ["F4502", "critical", "KeyRing Certificate THD_KEYRING expired"],
+            ],
+        ),
+        # FAIL_O - only expired certificate (F4503 - TP)
+        (
+            {
+                faultInst: read_data(dir, "faultInst_F4503.json")
+            },
+            False, 
+            {}, 
+            "6.1(5e)", 
+            [],
+            script.FAIL_O,
+            [
+                ["F4503", "critical", "TP Certificate THD_CA expired"],
+            ],
+        ),
+        # FAIL_O - only expired certificate (F3082 - SAML)
+        (
+            {
+                faultInst: read_data(dir, "faultInst_F3082.json")
+            },
+            False, 
+            {}, 
+            "6.1(5e)", 
+            [],
+            script.FAIL_O,
+            [
+                ["F3082", "critical", "SAML Encryption Certificate has expired"],
+            ],
+        ),
+        # FAIL_O - only expired factory certificate (F4753 - Factory)
+        (
+            {
+                faultInst: read_data(dir, "faultInst_F4753.json")
+            },
+            False,
+            {},
+            "6.1(5e)",
+            [],
+            script.FAIL_O,
+            [
+                ["F4753", "critical", "Factory certificate expired"],
+            ],
+        ),
+        # FAIL_O - multiple expired certificates
+        (
+            {
+                faultInst: read_data(dir, "faultInst_multiple_expired.json")
+            },
+            False, 
+            {}, 
+            "6.1(5e)", 
+            [],
+            script.FAIL_O,
+            [
+                ["F4502", "critical", "KeyRing Certificate THD_KEYRING expired"],
+                ["F4503", "critical", "TP Certificate THD_CA expired"],
+                ["F3082", "critical", "SAML Encryption Certificate has expired"],
+            ],
+        ),
+        # FAIL_O - mixed: both expiring and expired certificates (expired takes priority)
+        (
+            {
+                faultInst: read_data(dir, "faultInst_mixed.json")
+            },
+            False, 
+            {}, 
+            "6.1(5e)", 
+            [],
+            script.FAIL_O,
+            [
+                ["F4501", "major", "KeyRing Certificate KEYRING1 expiring"],
+                ["F4502", "critical", "KeyRing Certificate THD_KEYRING expired"],
+                ["F3081", "major", "SAML Signing Certificate expiring in one month"],
+                ["F3082", "critical", "SAML Encryption Certificate has expired"],
+            ],
+        ),
+        # PASS - faults exist but not in raised/soaking state (cleared/retaining)
+        (
+            {
+                faultInst: read_data(dir, "faultInst_cleared.json")
+            },
+            False, 
+            {}, 
+            "6.1(5e)", 
+            [],
+            script.PASS,
+            [],
+        ),
+
+        # ==== Version gating: only applicable fault codes are queried ====
+
+        # 6.1(1e) <= cversion < 6.1(5e): 6 codes (no factory). TP expired.
+        (
+            {
+                faultInst_pre_factory: read_data(dir, "faultInst_F4503.json")
+            },
+            False, 
+            {}, 
+            "6.1(1e)", 
+            [],
+            script.FAIL_O,
+            [
+                ["F4503", "critical", "TP Certificate THD_CA expired"],
+            ],
+        ),
+        # 6.0(4c) <= cversion < 6.1(1e): KeyRing + SAML only. KeyRing expired.
+        (
+            {
+                faultInst_keyring_saml: read_data(dir, "faultInst_F4502.json")
+            },
+            False, 
+            {}, 
+            "6.0(4c)", 
+            [],
+            script.FAIL_O,
+            [
+                ["F4502", "critical", "KeyRing Certificate THD_KEYRING expired"],
+            ],
+        ),
+        # 3.1(2f) <= cversion < 6.0(4c): SAML only. Expired.
+        (
+            {
+                faultInst_saml: read_data(dir, "faultInst_F3082.json")
+            },
+            False, 
+            {}, 
+            "5.2(7g)", 
+            [],
+            script.FAIL_O,
+            [
+                ["F3082", "critical", "SAML Encryption Certificate has expired"],
+            ],
+        ),
+        # 3.1(2f) <= cversion < 6.0(4c): SAML only, none raised.
+        (
+            {faultInst_saml: []},
+            False, 
+            {}, 
+            "5.2(7g)", 
+            [],
+            script.PASS,
+            [],
+        ),
+        # cversion < 3.1(2f): no applicable fault codes, no fault query issued.
+        (
+            {}, 
+            False, 
+            {}, 
+            "2.3(1a)", 
+            [],
+            script.PASS,
+            [],
+        ),
+
+        # ==== Factory certificate SSH check (cversion < 6.1(5e)) ====
+
+        # PASS - manufacturing certificate valid (far future)
+        (
+            {
+                faultInst_pre_factory: []
+            },
+            False, 
+            ssh_cmds(VERIFYAPIC_VALID), 
+            "6.1(4a)", 
+            fabric_nodes_ssh,
+            script.PASS,
+            [],
+        ),
+        # FAIL_O - manufacturing certificate expired
+        (
+            {
+                faultInst_pre_factory: []
+            },
+            False, 
+            ssh_cmds(VERIFYAPIC_EXPIRED), 
+            "6.1(4a)", 
+            fabric_nodes_ssh,
+            script.FAIL_O,
+            [
+                ["N/A", "critical",
+                 "APIC 1 (apic1): manufacturing certificate expired on 2024-05-14 20:25:42 UTC"],
+            ],
+        ),
+        # MANUAL - manufacturing certificate expiring within threshold (30 days)
+        (
+            {faultInst_pre_factory: []},
+            False, 
+            ssh_cmds(VERIFYAPIC_EXPIRING), 
+            "6.1(4a)", 
+            fabric_nodes_ssh,
+            script.MANUAL,
+            [
+                ["N/A", "major",
+                 "APIC 1 (apic1): manufacturing certificate expiring on 2026-08-01 06:57:40 UTC"],
+            ],
+        ),
+        # ERROR - SSH connection failure while verifying manufacturing certificate
+        (
+            {
+                faultInst_pre_factory: []
+            },
+            True, 
+            {}, 
+            "6.1(4a)", 
+            fabric_nodes_ssh,
+            script.ERROR,
+            [
+                ["N/A", "error",
+                 "APIC 1 (apic1): unable to verify manufacturing certificate - Simulated exception at connect()"],
+            ],
+        ),
+        # FAIL_O - combined: a raised fault AND an expired manufacturing cert (both reported)
+        (
+            {faultInst_pre_factory: read_data(dir, "faultInst_F4502.json")},
+            False, 
+            ssh_cmds(VERIFYAPIC_EXPIRED), 
+            "6.1(4a)", 
+            fabric_nodes_ssh,
+            script.FAIL_O,
+            [
+                ["F4502", "critical", "KeyRing Certificate THD_KEYRING expired"],
+                ["N/A", "critical",
+                 "APIC 1 (apic1): manufacturing certificate expired on 2024-05-14 20:25:42 UTC"],
+            ],
+        ),
+        # FAIL_O - 3 APICs, only apic2 has an expired manufacturing cert
+        (
+            {faultInst_pre_factory: []},
+            False,
+            ssh_cmds({
+                "10.0.0.1": VERIFYAPIC_VALID,
+                "10.0.0.2": VERIFYAPIC_EXPIRED,
+                "10.0.0.3": VERIFYAPIC_VALID,
+            }),
+            "6.1(4a)",
+            fabric_nodes_multi,
+            script.FAIL_O,
+            [
+                ["N/A", "critical",
+                 "APIC 2 (apic2): manufacturing certificate expired on 2024-05-14 20:25:42 UTC"],
+            ],
+        ),
+    ],
+)
+def test_logic(run_check, mock_icurl, mock_conn, cversion, fabric_nodes, expected_result, expected_data):
+    result = run_check(
+        cversion=script.AciVersion(cversion) if cversion else None,
+        username="fake_username",
+        password="fake_password",
+        fabric_nodes=fabric_nodes,
+    )
+    assert result.result == expected_result
+    assert result.data == expected_data

--- a/tests/checks/certificate_expiration_check/test_certificate_expiration_check.py
+++ b/tests/checks/certificate_expiration_check/test_certificate_expiration_check.py
@@ -26,10 +26,10 @@ def fault_query(codes):
 
 
 # icurl queries per applicable version range
-faultInst = fault_query(MASTER_ORDER)                                    # cversion >= 6.1(5e)
-faultInst_pre_factory = fault_query(["F4501", "F4502", "F4503", "F4617", "F3081", "F3082"])  # 6.1(1e)–6.1(5e)
-faultInst_keyring_saml = fault_query(["F4501", "F4502", "F3081", "F3082"])                    # 6.0(4c)–6.1(1e)
-faultInst_saml = fault_query(["F3081", "F3082"])                                              # 3.1(2f)–6.0(4c)
+faultInst = fault_query(MASTER_ORDER)
+faultInst_pre_factory = fault_query(["F4501", "F4502", "F4503", "F4617", "F3081", "F3082"])
+faultInst_keyring_saml = fault_query(["F4501", "F4502", "F3081", "F3082"])
+faultInst_saml = fault_query(["F3081", "F3082"])
 
 
 # --- Factory certificate (F4752/F4753) SSH check test data ---
@@ -367,7 +367,7 @@ def ssh_cmds(outputs):
             script.FAIL_O,
             [
                 ["N/A", "critical",
-                 "APIC 1 (apic1): manufacturing certificate expired on 2024-05-14 20:25:42 UTC"],
+                 "APIC 1 (apic1): factory certificate expired on 2024-05-14 20:25:42 UTC"],
             ],
         ),
         # MANUAL - manufacturing certificate expiring within threshold (30 days)
@@ -380,7 +380,7 @@ def ssh_cmds(outputs):
             script.MANUAL,
             [
                 ["N/A", "major",
-                 "APIC 1 (apic1): manufacturing certificate expiring on 2026-08-01 06:57:40 UTC"],
+                 "APIC 1 (apic1): factory certificate expiring on 2026-08-01 06:57:40 UTC"],
             ],
         ),
         # ERROR - SSH connection failure while verifying manufacturing certificate
@@ -395,7 +395,7 @@ def ssh_cmds(outputs):
             script.ERROR,
             [
                 ["N/A", "error",
-                 "APIC 1 (apic1): unable to verify manufacturing certificate - Simulated exception at connect()"],
+                 "APIC 1 (apic1): unable to verify factory certificate - Simulated exception at connect()"],
             ],
         ),
         # FAIL_O - combined: a raised fault AND an expired manufacturing cert (both reported)
@@ -409,7 +409,7 @@ def ssh_cmds(outputs):
             [
                 ["F4502", "critical", "KeyRing Certificate THD_KEYRING expired"],
                 ["N/A", "critical",
-                 "APIC 1 (apic1): manufacturing certificate expired on 2024-05-14 20:25:42 UTC"],
+                 "APIC 1 (apic1): factory certificate expired on 2024-05-14 20:25:42 UTC"],
             ],
         ),
         # FAIL_O - 3 APICs, only apic2 has an expired manufacturing cert
@@ -426,7 +426,7 @@ def ssh_cmds(outputs):
             script.FAIL_O,
             [
                 ["N/A", "critical",
-                 "APIC 2 (apic2): manufacturing certificate expired on 2024-05-14 20:25:42 UTC"],
+                 "APIC 2 (apic2): factory certificate expired on 2024-05-14 20:25:42 UTC"],
             ],
         ),
     ],

--- a/tests/checks/certificate_expiration_check/test_certificate_expiration_check.py
+++ b/tests/checks/certificate_expiration_check/test_certificate_expiration_check.py
@@ -3,33 +3,8 @@ import pytest
 import logging
 import importlib
 from helpers.utils import read_data
-from datetime import datetime
-
-FIXED_UTC_NOW = datetime(2026, 7, 15, 6, 35, 30)
-DATE_OUTPUT = "Wed Jul 15 06:35:30 UTC 2026\nfab-apic#"
-
-LEAF_SPINE_EXPIRED_TS = "2024-05-14T20:25:42.000+00:00"
-LEAF_SPINE_EXPIRING_TS = "2026-08-01T06:57:40.000+00:00"
-
 
 script = importlib.import_module("aci-preupgrade-validation-script")
-Result = script.Result
-
-@pytest.fixture(autouse=True)
-def hardcode_current_time(monkeypatch):
-    class FrozenDateTime(datetime):
-        @classmethod
-        def utcnow(cls):
-            return FIXED_UTC_NOW
-        
-        @classmethod
-        def now(cls, tz=None):
-            if tz is not None:
-                return FIXED_UTC_NOW.replace(tzinfo=tz)
-            else:
-                return FIXED_UTC_NOW
-    
-    monkeypatch.setattr(script, "datetime", FrozenDateTime)
 
 log = logging.getLogger(__name__)
 dir = os.path.dirname(os.path.abspath(__file__))
@@ -54,8 +29,6 @@ faultInst = fault_query(MASTER_ORDER)
 faultInst_pre_factory = fault_query(["F4501", "F4502", "F4503", "F4617", "F3081", "F3082"])
 faultInst_keyring_saml = fault_query(["F4501", "F4502", "F3081", "F3082"])
 faultInst_saml = fault_query(["F3081", "F3082"])
-pkiFabricNodeSSLCertificate = "pkiFabricNodeSSLCertificate.json"
-
 
 # --- Factory certificate (F4752/F4753) SSH check test data ---
 fabric_nodes_ssh = [
@@ -66,16 +39,6 @@ fabric_nodes_multi = [
     {"fabricNode": {"attributes": {"id": "1", "name": "apic1", "role": "controller", "address": "10.0.0.1"}}},
     {"fabricNode": {"attributes": {"id": "2", "name": "apic2", "role": "controller", "address": "10.0.0.2"}}},
     {"fabricNode": {"attributes": {"id": "3", "name": "apic3", "role": "controller", "address": "10.0.0.3"}}},
-]
-
-fabric_nodes_leaf_spine = [
-    {"fabricNode": {"attributes": {"id": "101", "name": "leaf101", "role": "leaf", "dn": "topology/pod-1/node-101"}}},
-    {"fabricNode": {"attributes": {"id": "201", "name": "spine201", "role": "spine", "dn": "topology/pod-1/node-201"}}},
-]
-
-fabric_nodes_controller_leaf = [
-    {"fabricNode": {"attributes": {"id": "1", "name": "apic1", "role": "controller", "address": "10.0.0.1"}}},
-    {"fabricNode": {"attributes": {"id": "101", "name": "leaf101", "role": "leaf", "dn": "topology/pod-1/node-101"}}},
 ]
 
 DATE_OUTPUT = "Wed Jul 15 06:35:30 UTC 2026\nfab-apic#"
@@ -512,204 +475,6 @@ def ssh_cmds(outputs):
             [
                 ["N/A", "critical",
                  "APIC 2 (apic2): factory certificate expired on 2024-05-14 20:25:42 UTC"],
-            ],
-        ),
-        # MANUAL - leaf/spine cert expiring within threshold
-        (
-            {
-                faultInst: [],
-                pkiFabricNodeSSLCertificate: [
-                    {
-                        "pkiFabricNodeSSLCertificate": {
-                            "attributes": {
-                                "nodeId": "101",
-                                "validityNotAfter": LEAF_SPINE_EXPIRING_TS
-                            }
-                        }
-                    }
-                ],
-            },
-            False,
-            {},
-            "6.1(5e)",
-            fabric_nodes_leaf_spine,
-            script.MANUAL,
-            [
-                ["N/A", "major",
-                 "Node 101 (leaf101): certificate expiring on 2026-08-01 06:57:40 UTC"],
-            ],
-        ),
-        # FAIL_O - leaf/spine cert expired via pkiFabricNodeSSLCertificate validityNotAfter
-        (
-            {
-                faultInst: [],
-                pkiFabricNodeSSLCertificate: [
-                    {
-                        "pkiFabricNodeSSLCertificate": {
-                            "attributes": {
-                                "nodeId": "101",
-                                "validityNotAfter": "2024-05-14T20:25:42.000+00:00"
-                            }
-                        }
-                    }
-                ],
-            },
-            False,
-            {},
-            "6.1(5e)",
-            fabric_nodes_leaf_spine,
-            script.FAIL_O,
-            [
-                ["N/A", "critical",
-                 "Node 101 (leaf101): certificate expired on 2024-05-14 20:25:42 UTC"],
-            ],
-        ),
-        # FAIL_O - leaf/spine combination: one expired and one expiring
-        (
-            {
-                faultInst: [],
-                pkiFabricNodeSSLCertificate: [
-                    {
-                        "pkiFabricNodeSSLCertificate": {
-                            "attributes": {
-                                "nodeId": "101",
-                                "validityNotAfter": LEAF_SPINE_EXPIRED_TS
-                            }
-                        }
-                    },
-                    {
-                        "pkiFabricNodeSSLCertificate": {
-                            "attributes": {
-                                "nodeId": "201",
-                                "validityNotAfter": LEAF_SPINE_EXPIRING_TS
-                            }
-                        }
-                    },
-                ],
-            },
-            False,
-            {},
-            "6.1(5e)",
-            fabric_nodes_leaf_spine,
-            script.FAIL_O,
-            [
-                ["N/A", "critical",
-                 "Node 101 (leaf101): certificate expired on 2024-05-14 20:25:42 UTC"],
-                ["N/A", "major",
-                 "Node 201 (spine201): certificate expiring on 2026-08-01 06:57:40 UTC"],
-            ],
-        ),
-        # ERROR - leaf/spine cert missing validityNotAfter
-        (
-            {
-                faultInst: [],
-                pkiFabricNodeSSLCertificate: [
-                    {
-                        "pkiFabricNodeSSLCertificate": {
-                            "attributes": {
-                                "nodeId": "201",
-                                "validityNotAfter": ""
-                            }
-                        }
-                    }
-                ],
-            },
-            False,
-            {},
-            "6.1(5e)",
-            fabric_nodes_leaf_spine,
-            script.ERROR,
-            [
-                ["N/A", "error",
-                 "Node 201 (spine201): unable to determine certificate expiry date"],
-            ],
-        ),
-        # ERROR - leaf/spine cert has unparseable validityNotAfter
-        (
-            {
-                faultInst: [],
-                pkiFabricNodeSSLCertificate: [
-                    {
-                        "pkiFabricNodeSSLCertificate": {
-                            "attributes": {
-                                "nodeId": "101",
-                                "validityNotAfter": "not-a-date"
-                            }
-                        }
-                    }
-                ],
-            },
-            False,
-            {},
-            "6.1(5e)",
-            fabric_nodes_leaf_spine,
-            script.ERROR,
-            [
-                ["N/A", "error",
-                 "Node 101 (leaf101): unable to parse certificate expiry date 'not-a-date'"],
-            ],
-        ),
-        # FAIL_O - APIC fault + APIC factory cert expired + leaf cert expired
-        (
-            {
-                faultInst_pre_factory: read_data(dir, "faultInst_F4502.json"),
-                pkiFabricNodeSSLCertificate: [
-                    {
-                        "pkiFabricNodeSSLCertificate": {
-                            "attributes": {
-                                "nodeId": "101",
-                                "validityNotAfter": LEAF_SPINE_EXPIRED_TS
-                            }
-                        }
-                    }
-                ],
-            },
-            False,
-            ssh_cmds(VERIFYAPIC_EXPIRED),
-            "6.1(4a)",
-            fabric_nodes_controller_leaf,
-            script.FAIL_O,
-            [
-                ["F4502", "critical", "KeyRing Certificate THD_KEYRING expired"],
-                ["N/A", "critical",
-                 "APIC 1 (apic1): factory certificate expired on 2024-05-14 20:25:42 UTC"],
-                ["N/A", "critical",
-                 "Node 101 (leaf101): certificate expired on 2024-05-14 20:25:42 UTC"],
-            ],
-        ),
-        # ERROR - mixed leaf/spine data: one expired + one missing validityNotAfter (error takes priority)
-        (
-            {
-                faultInst: [],
-                pkiFabricNodeSSLCertificate: [
-                    {
-                        "pkiFabricNodeSSLCertificate": {
-                            "attributes": {
-                                "nodeId": "101",
-                                "validityNotAfter": LEAF_SPINE_EXPIRED_TS
-                            }
-                        }
-                    },
-                    {
-                        "pkiFabricNodeSSLCertificate": {
-                            "attributes": {
-                                "nodeId": "201",
-                                "validityNotAfter": ""
-                            }
-                        }
-                    },
-                ],
-            },
-            False,
-            {},
-            "6.1(5e)",
-            fabric_nodes_leaf_spine,
-            script.ERROR,
-            [
-                ["N/A", "critical",
-                "Node 101 (leaf101): certificate expired on 2024-05-14 20:25:42 UTC"],
-                ["N/A", "error",
-                "Node 201 (spine201): unable to determine certificate expiry date"],
             ],
         ),
     ],


### PR DESCRIPTION
Detection logic:

1. Find the fault using below query 
       'faultInst.json?query-target-filter=or(eq(faultInst.code,"F4501"),eq(faultInst.code,"F4502"),eq(faultInst.code,"F4503"),eq(faultInst.code,"F3081"),eq(faultInst.code,"F3082"),eq(faultInst.code,"F4617"),eq(faultInst.code,"F4752"),eq(faultInst.code,"F4753"))'
 
2. if one fault F4501, F3081, F4617, F4752 found and state is “raised” or “soaking”
         Result = Manual & recommended_action ="Renew the certificate(s) before it expires to avoid service disruption."
 
3. if one fault F4502, F4503, F3082, F4753 and state is “raised” or “soaking”
          Result = FAIL_O & recommended_action="Renew the certificate(s) immediately to restore functionality."
 
4. if faults found as combination (e.g. expiring F3081 & expired F4502 ) means 
          Result = FAIL_O & recommended_action="Renew expired certificate(s) immediately. For certificate(s) approaching expiry, renew before they expire to avoid service disruption."
          
 
 Faults            Short Description                             Introduced         First build
F3081, F3082      SAML encryption cert expiring/expired     2018-02-22        3.1(2f)
F4501, F4502      KeyRing cert expiring/expired             2023-09-13        6.0(4c)
F4503, F4617      TP cert expired/expiring                   2024-04-22        6.1(1e)
F4752,F4753              Factory cert expiring/expired                                                            6.1(5e)


For Factory certificate status if cversion < 6.1(5e), check via cli command "acidiag verifyapic"

Fixes #408