### PR TITLE
Support compact equipment disk usage changeSet

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -5845,7 +5845,8 @@ def equipment_disk_limits_exceeded(**kwargs):
     recommended_action = 'Review the reference document for commands to validate disk usage'
     doc_url = 'https://datacenter.github.io/ACI-Pre-Upgrade-Validation-Script/validations/#equipment-disk-limits'
 
-    usage_regex = r"avail \(New: (?P<avail>\d+)\).+used \(New: (?P<used>\d+)\)"
+    avail_regex = r"(?:^|,\s*)avail(?:\s+\(New:\s*|:\s*)(?P<value>\d+)(?:\)|(?=,|$))"
+    used_regex = r"(?:^|,\s*)used(?:\s+\(New:\s*|:\s*)(?P<value>\d+)(?:\)|(?=,|$))"
     f182x_api = 'faultInst.json'
     f182x_api += '?query-target-filter=or(eq(faultInst.code,"F1820"),eq(faultInst.code,"F1821"),eq(faultInst.code,"F1822"))'
     faults = icurl('class', f182x_api)
@@ -5854,11 +5855,14 @@ def equipment_disk_limits_exceeded(**kwargs):
         percent = "NA"
         attributes = faultInst['faultInst']['attributes']
 
-        usage_match = re.search(usage_regex, attributes['changeSet'])
-        if usage_match:
-            avail = int(usage_match.group('avail'))
-            used = int(usage_match.group('used'))
-            percent = round((used / (avail + used)) * 100)
+        avail_match = re.search(avail_regex, attributes['changeSet'])
+        used_match = re.search(used_regex, attributes['changeSet'])
+        if avail_match and used_match:
+            avail = int(avail_match.group('value'))
+            used = int(used_match.group('value'))
+            total = avail + used
+            if total:
+                percent = int(round((used / total) * 100))
 
         dn_match = re.search(node_regex, attributes['dn'])
         if dn_match:

--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -1528,6 +1528,8 @@ This fault occurs when the disk usage of a partiton increases beyond its thresho
 
 This fault also occurs when the MTS buffer memory usage increases beyond its threshold. /proc/isan/sw/mts/mem/stats is checked when this scenario occurs.
 
+The check calculates utilization from the available and used values reported by each fault. Both APIC `changeSet` formats are supported.
+
 Recommended Action:
 
 1. Check `df -h` output on affected node to see the usage of the partition.

--- a/tests/checks/equipment_disk_limits_exceeded/faultInst_compact.json
+++ b/tests/checks/equipment_disk_limits_exceeded/faultInst_compact.json
@@ -1,0 +1,15 @@
+[
+  {
+    "faultInst": {
+      "attributes": {
+        "cause": "equipment-disk-limits-exceeded",
+        "changeSet": "avail:1959076, memAlert:minor, name:ifc:cfg, path:/mnt/ifc/cfg, used:8207252",
+        "code": "F1820",
+        "descr": "Disk usage for /mnt/ifc/cfg is above normal",
+        "dn": "topology/pod-1/node-107/sys/eqptcapacity/fspartition-ifc:cfg/fault-F1820",
+        "lc": "raised",
+        "rule": "eqptcapacity-fspartition-fs-partition-limits-exceeded-minor"
+      }
+    }
+  }
+]

--- a/tests/checks/equipment_disk_limits_exceeded/test_equipment_disk_limits_exceeded.py
+++ b/tests/checks/equipment_disk_limits_exceeded/test_equipment_disk_limits_exceeded.py
@@ -16,18 +16,46 @@ f182x_api += '?query-target-filter=or(eq(faultInst.code,"F1820"),eq(faultInst.co
 
 
 @pytest.mark.parametrize(
-    "icurl_outputs, expected_result",
+    "icurl_outputs, expected_result, expected_data, expected_unformatted_data",
     [
         (
             {f182x_api: read_data(dir, "faultInst_neg.json")},
             script.PASS,
+            [],
+            [],
         ),
         (
             {f182x_api: read_data(dir, "faultInst_pos.json")},
             script.FAIL_UF,
-        )
+            [
+                ["1", "101", "F1820", 98, "Disk usage for /mnt/ifc/log is high on node 101 of fabric POD1 with a hostname leaf1"],
+                ["1", "102", "F1821", 97, "Disk usage for /mnt/ifc/cfg is high on node 102 of fabric POD1 with a hostname leaf2"],
+                ["1", "104", "F1821", 100, "Disk usage for / is high on node 104 of fabric POD1 with a hostname LEAF-104"],
+            ],
+            [[
+                "topology/pod-1/node-[103]/sys/eqptcapacity/fspartition-ifc:cfg/fault-F1821",
+                "NA",
+                "Disk usage for /mnt/ifc/cfg is high on node 103 of fabric POD1 with a hostname leaf3",
+            ]],
+        ),
+        (
+            {f182x_api: read_data(dir, "faultInst_compact.json")},
+            script.FAIL_UF,
+            [["1", "107", "F1820", 81, "Disk usage for /mnt/ifc/cfg is above normal"]],
+            [],
+        ),
     ],
 )
-def test_logic(run_check, mock_icurl, expected_result):
+def test_logic(
+    run_check,
+    mock_icurl,
+    expected_result,
+    expected_data,
+    expected_unformatted_data,
+):
     result = run_check()
     assert result.result == expected_result
+    assert result.data == expected_data
+    assert result.unformatted_data == expected_unformatted_data
+    for row in result.data:
+        assert isinstance(row[3], int)


### PR DESCRIPTION
## Summary
- parse both legacy and compact F1820/F1821/F1822 `changeSet` formats
- preserve fault-driven upgrade failures and report malformed values as `NA`
- add exact result assertions and issue-derived compact-format coverage
- document support for both APIC serializations

## Validation
- `pytest tests/checks/equipment_disk_limits_exceeded/test_equipment_disk_limits_exceeded.py` (3 passed)
- `pytest` (917 passed)
- `python -m py_compile aci-preupgrade-validation-script.py`
- `git diff --check`

Closes #369

Fixes #369