### PR TITLE
docs: clarify recommended action metadata

### DIFF
--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -73,7 +73,7 @@ Each check has a unique result which will help determine how to proceed. The res
 
 ### Recommended action in JSON results
 
-The per-check JSON schema was added for the built-in pre-upgrade validation workflow in APIC 6.2 and later. The APIC presentation layer expects `recommended_action` as static rule metadata, so the field can be populated even when `ruleStatus` is `passed`.
+The per-check JSON schema was added for the built-in pre-upgrade validation workflow in APIC 6.2 and later. The APIC presentation layer expects `recommended_action` as static rule metadata, so the field can be populated even when `ruleStatus` is `passed`. See Cisco’s [Pre-upgrade validator examples for APIC 6.2(1)](https://www.cisco.com/c/en/us/td/docs/dcn/aci/apic/all/apic-installation-aci-upgrade-downgrade/Cisco-APIC-Installation-ACI-Upgrade-Downgrade-Guide/g-pre-upgrade-checklists/examples-of-pre-upgrade-validator-apic.html#Cisco_Reference.dita_53db0ff6-cc90-4543-80e0-091fc41dc962__section_vq4_5lv_qhc).
 
 Use `ruleStatus` to determine whether the recommendation is actionable. A populated `recommended_action` does not indicate a problem when `ruleStatus` is `passed`; standalone consumers should act on it only when `ruleStatus` is `failed`.
 

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -60,7 +60,7 @@ TOTAL                    : 36
       Result Bundle: /data/techsupport/preupgrade_validator_2021-07-30T13-28-25-0700.tgz
 ```
 
-## Results
+## Result types and JSON output
 
 Each check has a unique result which will help determine how to proceed. The results are explained as follows:
 
@@ -70,8 +70,6 @@ Each check has a unique result which will help determine how to proceed. The res
 - **MANUAL CHECK REQUIRED** - The check has completed, and the specific check needs to be investigated manually using the steps outlines in the "ACI Upgrade Guide".
 - **N/A** - The check completed successfully, and the ACI fabric is not susceptible because the needed configuration is not deployed.
 - **ERROR** - The check did not complete successfully, and needs further investigation.
-
-### Recommended action in JSON results
 
 The per-check JSON schema was added for the built-in pre-upgrade validation workflow in APIC 6.2 and later. The APIC presentation layer expects `recommended_action` as static rule metadata, so the field can be populated even when `ruleStatus` is `passed`. See Cisco’s [Pre-upgrade validator examples for APIC 6.2(1)](https://www.cisco.com/c/en/us/td/docs/dcn/aci/apic/all/apic-installation-aci-upgrade-downgrade/Cisco-APIC-Installation-ACI-Upgrade-Downgrade-Guide/g-pre-upgrade-checklists/examples-of-pre-upgrade-validator-apic.html#Cisco_Reference.dita_53db0ff6-cc90-4543-80e0-091fc41dc962__section_vq4_5lv_qhc).
 

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -71,6 +71,12 @@ Each check has a unique result which will help determine how to proceed. The res
 - **N/A** - The check completed successfully, and the ACI fabric is not susceptible because the needed configuration is not deployed.
 - **ERROR** - The check did not complete successfully, and needs further investigation.
 
+### Recommended action in JSON results
+
+The per-check JSON schema was added for the built-in pre-upgrade validation workflow in APIC 6.2 and later. The APIC presentation layer expects `recommended_action` as static rule metadata, so the field can be populated even when `ruleStatus` is `passed`.
+
+Use `ruleStatus` to determine whether the recommendation is actionable. A populated `recommended_action` does not indicate a problem when `ruleStatus` is `passed`; standalone consumers should act on it only when `ruleStatus` is `failed`.
+
 ## Logs
 
 A single log bundle will be generated with each run of the script


### PR DESCRIPTION
## Summary

- explain that the per-check JSON schema supports APIC 6.2+ built-in validation
- clarify that `recommended_action` is static metadata used by the APIC presentation layer
- direct standalone consumers to use `ruleStatus` when deciding whether an action applies

A populated recommendation on a passed rule does not indicate a problem.

Fixes #389.

## Validation

- `git diff --check`
- Tests not run because this is a documentation-only clarification.

Fixes #389