### PR TITLE
fix(ci): harden v4.2 integration testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@
 # since gitlab ci can only cache local items.
 variables:
   PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
+  INTEGRATION_RUN_ID: "$CI_PROJECT_ID-$CI_PIPELINE_ID-$CI_JOB_ID"
 
 stages:
   - unit_test
@@ -85,6 +86,7 @@ test:py38:
     when: always
     paths:
       - $CI_PROJECT_DIR/tests/*.log
+      - $CI_PROJECT_DIR/tests/*.tgz
   cache:
     key:
       files:
@@ -96,6 +98,15 @@ test:py38:
   retry:
     max: 1
     when: runner_system_failure
+
+# =============================================================================
+# Integration Test - Actual Fabric Versions
+# =============================================================================
+test:integration:actual-current-version:
+  <<: *integration_template
+  script:
+    - 'curl --header "PRIVATE-TOKEN: $integration_repo_token" "$repo_url/test_fabrics.yaml/raw?ref=main" -o test_fabrics.yaml'
+    - python3 runner.py -f ../aci-preupgrade-validation-script.py -i test_fabrics.yaml -k $decode_key
 
 # =============================================================================
 # Integration Tests - 5.x Internal Upgrades

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,7 +106,6 @@ test:integration:5.2.4d-to-5.2.8f:
     FABRIC_CVERSION: "5.2(4d)"
     FABRIC_TVERSION: "5.2(8f)"
   script:
-    - cd tests
     - 'curl --header "PRIVATE-TOKEN: $integration_repo_token" "$repo_url/test_fabrics.yaml/raw?ref=main" -o test_fabrics.yaml'
     - python3 runner.py -f ../aci-preupgrade-validation-script.py -i test_fabrics.yaml -k $decode_key --cversion "$FABRIC_CVERSION" --tversion "$FABRIC_TVERSION"
 
@@ -119,7 +118,6 @@ test:integration:5.2.4d-to-6.0.2h:
     FABRIC_CVERSION: "5.2(4d)"
     FABRIC_TVERSION: "6.0(2h)"
   script:
-    - cd tests
     - 'curl --header "PRIVATE-TOKEN: $integration_repo_token" "$repo_url/test_fabrics.yaml/raw?ref=main" -o test_fabrics.yaml'
     - python3 runner.py -f ../aci-preupgrade-validation-script.py -i test_fabrics.yaml -k $decode_key --cversion "$FABRIC_CVERSION" --tversion "$FABRIC_TVERSION"
 
@@ -129,7 +127,6 @@ test:integration:5.2.6e-to-6.0.5a:
     FABRIC_CVERSION: "5.2(6e)"
     FABRIC_TVERSION: "6.0(5a)"
   script:
-    - cd tests
     - 'curl --header "PRIVATE-TOKEN: $integration_repo_token" "$repo_url/test_fabrics.yaml/raw?ref=main" -o test_fabrics.yaml'
     - python3 runner.py -f ../aci-preupgrade-validation-script.py -i test_fabrics.yaml -k $decode_key --cversion "$FABRIC_CVERSION" --tversion "$FABRIC_TVERSION"
 
@@ -142,7 +139,6 @@ test:integration:5.2.8d-to-6.1.1f:
     FABRIC_CVERSION: "5.2(8d)"
     FABRIC_TVERSION: "6.1(1f)"
   script:
-    - cd tests
     - 'curl --header "PRIVATE-TOKEN: $integration_repo_token" "$repo_url/test_fabrics.yaml/raw?ref=main" -o test_fabrics.yaml'
     - python3 runner.py -f ../aci-preupgrade-validation-script.py -i test_fabrics.yaml -k $decode_key --cversion "$FABRIC_CVERSION" --tversion "$FABRIC_TVERSION"
 
@@ -152,7 +148,6 @@ test:integration:5.3.2d-to-6.1.4h:
     FABRIC_CVERSION: "5.3(2d)"
     FABRIC_TVERSION: "6.1(4h)"
   script:
-    - cd tests
     - 'curl --header "PRIVATE-TOKEN: $integration_repo_token" "$repo_url/test_fabrics.yaml/raw?ref=main" -o test_fabrics.yaml'
     - python3 runner.py -f ../aci-preupgrade-validation-script.py -i test_fabrics.yaml -k $decode_key --cversion "$FABRIC_CVERSION" --tversion "$FABRIC_TVERSION"
 
@@ -165,6 +160,5 @@ test:integration:6.0.2a-to-6.1.4h:
     FABRIC_CVERSION: "6.0(2a)"
     FABRIC_TVERSION: "6.1(4h)"
   script:
-    - cd tests
     - 'curl --header "PRIVATE-TOKEN: $integration_repo_token" "$repo_url/test_fabrics.yaml/raw?ref=main" -o test_fabrics.yaml'
     - python3 runner.py -f ../aci-preupgrade-validation-script.py -i test_fabrics.yaml -k $decode_key --cversion "$FABRIC_CVERSION" --tversion "$FABRIC_TVERSION"


### PR DESCRIPTION
## Summary
- remove duplicate integration test directory changes
- restore an actual detected-current-version integration job alongside six override jobs
- pass cross-project unique run IDs through CI
- retain TGZ debug bundles as integration artifacts

## Validation
- parsed GitLab CI YAML with PyYAML
- asserted seven integration jobs
- asserted actual-version job has no current/target overrides
- asserted TGZ artifact inheritance
- `git diff --check`
- runner repository: 14 unit tests passed