### PR TITLE
Fix FX3 memory query filter limit on large fabrics

### DIFF
--- a/aci-preupgrade-validation-script.py
+++ b/aci-preupgrade-validation-script.py
@@ -6828,12 +6828,8 @@ def n9k_c93180yc_fx3_switch_memory_check(fabric_nodes, **kwargs):
         result = NA
         msg = 'No N9K-C93180YC-FX3 switches found. Skipping.'
     else:
-        node_ids = [node['fabricNode']['attributes']['id'] for node in affected_nodes]
-        node_filter = 'or({})'.format(','.join(
-            'wcard(procMemUsage.dn,"node-{}/")'.format(nid) for nid in node_ids
-        ))
-        query = 'procMemUsage.json?query-target-filter=and({},wcard(procMemUsage.dn,"memusage-sup"),lt(procMemUsage.Total,"{}"))'.format(
-            node_filter, min_memory_kb
+        query = 'procMemUsage.json?query-target-filter=and(wcard(procMemUsage.dn,"memusage-sup"),lt(procMemUsage.Total,"{}"))'.format(
+            min_memory_kb
         )
         proc_mem_mos = icurl('class', query)
 

--- a/tests/checks/n9k_c93180yc_fx3_switch_memory_check/procMemUsage_lt32gb_unaffected.json
+++ b/tests/checks/n9k_c93180yc_fx3_switch_memory_check/procMemUsage_lt32gb_unaffected.json
@@ -1,0 +1,11 @@
+[
+    {
+        "procMemUsage": {
+            "attributes": {
+                "dn": "topology/pod-1/node-102/sys/procmem/memusage-sup",
+                "Modname": "sup",
+                "Total": "16000000"
+            }
+        }
+    }
+]

--- a/tests/checks/n9k_c93180yc_fx3_switch_memory_check/test_n9k_c93180yc_fx3_switch_memory_check.py
+++ b/tests/checks/n9k_c93180yc_fx3_switch_memory_check/test_n9k_c93180yc_fx3_switch_memory_check.py
@@ -11,8 +11,25 @@ dir = os.path.dirname(os.path.abspath(__file__))
 
 test_function = "n9k_c93180yc_fx3_switch_memory_check"
 
-# icurl queries - filtered by affected node IDs and memory threshold
-proc_mem_query_node101 = 'procMemUsage.json?query-target-filter=and(or(wcard(procMemUsage.dn,"node-101/")),wcard(procMemUsage.dn,"memusage-sup"),lt(procMemUsage.Total,"32000000"))'
+# icurl query - affected node IDs are filtered from the response
+proc_mem_query = 'procMemUsage.json?query-target-filter=and(wcard(procMemUsage.dn,"memusage-sup"),lt(procMemUsage.Total,"32000000"))'
+
+
+def make_fx3_nodes(count):
+    return [
+        {
+            "fabricNode": {
+                "attributes": {
+                    "dn": "topology/pod-1/node-{}".format(node_id),
+                    "id": str(node_id),
+                    "name": "leaf{}".format(node_id),
+                    "model": "N9K-C93180YC-FX3",
+                    "role": "leaf",
+                }
+            }
+        }
+        for node_id in range(101, 101 + count)
+    ]
 
 
 @pytest.mark.parametrize(
@@ -38,7 +55,7 @@ proc_mem_query_node101 = 'procMemUsage.json?query-target-filter=and(or(wcard(pro
         (
             read_data(dir, "fabricNode_one.json"),
             {
-                proc_mem_query_node101: [],
+                proc_mem_query: [],
             },
             script.PASS,
             '',
@@ -48,7 +65,27 @@ proc_mem_query_node101 = 'procMemUsage.json?query-target-filter=and(or(wcard(pro
         (
             read_data(dir, "fabricNode_two.json"),
             {
-                proc_mem_query_node101: [],
+                proc_mem_query: [],
+            },
+            script.PASS,
+            '',
+            [],
+        ),
+        # Low-memory results for other switch models are ignored
+        (
+            read_data(dir, "fabricNode_two.json"),
+            {
+                proc_mem_query: read_data(dir, "procMemUsage_lt32gb_unaffected.json"),
+            },
+            script.PASS,
+            '',
+            [],
+        ),
+        # Query remains below APIC's 20-expression limit on large fabrics
+        (
+            make_fx3_nodes(55),
+            {
+                proc_mem_query: [],
             },
             script.PASS,
             '',
@@ -58,7 +95,7 @@ proc_mem_query_node101 = 'procMemUsage.json?query-target-filter=and(or(wcard(pro
         (
             read_data(dir, "fabricNode_one.json"),
             {
-                proc_mem_query_node101: read_data(dir, "procMemUsage_lt32gb.json"),
+                proc_mem_query: read_data(dir, "procMemUsage_lt32gb.json"),
             },
             script.FAIL_O,
             (


### PR DESCRIPTION
## Summary
- replace the per-FX3-node APIC filter with one constant-size `procMemUsage` query
- filter the below-32GB response locally against the affected FX3 node IDs already present in `fabric_nodes`
- add regression coverage for 55 affected nodes and for excluding low-memory non-FX3 switches

## Validation
- `python3 -m pytest tests/checks/n9k_c93180yc_fx3_switch_memory_check/test_n9k_c93180yc_fx3_switch_memory_check.py` (7 passed)
- `python3 -m pytest` (1004 passed)
- GitLab integration pipeline 208, actual-current-version job 698: scale1 completed with 104 fabric nodes and 52 affected FX3 nodes; the constant-size query returned 7 below-threshold supervisor records, none from affected FX3 nodes; the check passed with no APIC 301/filter-expression-limit error

Fixes #423
