### PR TITLE
Document scalability spillover risk during upgrades

### DIFF
--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -1395,7 +1395,7 @@ The script checks faults raised under `eqptcapacityEntity`, which are TCA (Thres
 
 A raised TCA indicates that a configured capacity threshold was crossed; it does not necessarily indicate a current outage. The script reports `FAIL - OUTAGE WARNING!!` because switch reboots during an upgrade can cause endpoints, routes, contracts, and other programmed resources to be temporarily redistributed to the remaining switches. This spillover can push a resource that is already near its limit, such as Policy CAM at 90%, beyond supported capacity and cause programming failures or traffic disruption. Similar post-reboot resource inconsistencies are described under [Policy CAM Programming for Contracts (F3545) and L3Out Subnets Programming for Contracts (F3544)][f15].
 
-Before upgrading, review the affected node and resource under `Operations > Capacity Dashboard > Leaf Capacity`, reduce utilization or otherwise restore sufficient capacity headroom, and resolve the fault. A currently stable fabric does not demonstrate that sufficient upgrade headroom exists.
+Before upgrading, review the affected node and resource under `Operations > Capacity Dashboard > Leaf Capacity` and examine the capacity headroom based on your network design, server connectivity and so on.
 
 Examples of what's monitored via `Operations > Capacity Dashboard > Leaf Capacity` are the number of endpoints such as MAC (Learned), IPv4 (Learned), Policy CAM, LPM, host routes, VLANs and so on.
 

--- a/docs/docs/validations.md
+++ b/docs/docs/validations.md
@@ -1393,7 +1393,9 @@ The fault F3545 occurs when the switch fails to activate a contract rule (zoning
 
 The script checks faults raised under `eqptcapacityEntity`, which are TCA (Threshold Crossed Alert) faults for various objects monitored in the **Capacity Dashboard** from `Operations > Capacity Dashboard > Leaf Capacity` on the Cisco APIC GUI.
 
-It is important to ensure that any capacity does not exceed its limit. When it's exceeding the limit, it may cause inconsistency on resources that are deployed before and after an upgrade just like it was warned for [Policy CAM Programming for Contracts (F3545) and L3Out Subnets Programming for Contracts (F3544)][f15].
+A raised TCA indicates that a configured capacity threshold was crossed; it does not necessarily indicate a current outage. The script reports `FAIL - OUTAGE WARNING!!` because switch reboots during an upgrade can cause endpoints, routes, contracts, and other programmed resources to be temporarily redistributed to the remaining switches. This spillover can push a resource that is already near its limit, such as Policy CAM at 90%, beyond supported capacity and cause programming failures or traffic disruption. Similar post-reboot resource inconsistencies are described under [Policy CAM Programming for Contracts (F3545) and L3Out Subnets Programming for Contracts (F3544)][f15].
+
+Before upgrading, review the affected node and resource under `Operations > Capacity Dashboard > Leaf Capacity`, reduce utilization or otherwise restore sufficient capacity headroom, and resolve the fault. A currently stable fabric does not demonstrate that sufficient upgrade headroom exists.
 
 Examples of what's monitored via `Operations > Capacity Dashboard > Leaf Capacity` are the number of endpoints such as MAC (Learned), IPv4 (Learned), Policy CAM, LPM, host routes, VLANs and so on.
 


### PR DESCRIPTION
## Summary
- clarify that a capacity TCA does not necessarily indicate a current outage
- explain how upgrade-driven resource redistribution can create spillover beyond supported capacity
- direct operators to restore sufficient capacity headroom before upgrading

## Validation
- `/Users/gmonroy/Library/Python/3.9/bin/mkdocs build --strict -f docs/mkdocs.yml`

Closes #427
